### PR TITLE
Also eval exports and global for js_beautify if necessary

### DIFF
--- a/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
@@ -122,7 +122,9 @@ class JsSanitizer
           
     private static ScriptObjectMirror getBeautifHandler(final ScriptEngine scriptEngine) {
       try {
-        return (ScriptObjectMirror) scriptEngine.eval("window.js_beautify;");
+        return scriptEngine.eval("window.js_beautify;") != null ? (ScriptObjectMirror) scriptEngine.eval("window.js_beautify;")
+        : scriptEngine.eval("exports.js_beautify;") != null ? (ScriptObjectMirror) scriptEngine.eval("exports.js_beautify;")
+        : (ScriptObjectMirror) scriptEngine.eval("global.js_beautify;");
       }
       catch(final ScriptException e) {
         // should never happen


### PR DESCRIPTION
Prevents NPE if js_beautify is defined inside exports or global instead of window.