### PR TITLE
Make interrupt-checking function injection during js sanitzation more precise to avoid eval errors on complex scripts

### DIFF
--- a/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
@@ -71,8 +71,9 @@ class JsSanitizer
       // every 10th statments ended with semicolon put intterupt checking function
       new PoisonPil(Pattern.compile("(([^;]+;){9}[^;]+(?<!break|continue);)\\n"), JS_INTERRUPTED_FUNCTION+"();\n"),
       // every (except switch) block start brace put intterupt checking function
-      new PoisonPil(Pattern.compile("(\\s*for\\s*\\([^\\{]+\\{)"), JS_INTERRUPTED_FUNCTION+"();"),
-      new PoisonPil(Pattern.compile("(\\s*function\\s*[^\\{]+\\{)"), JS_INTERRUPTED_FUNCTION+"();"),
+      new PoisonPil(Pattern.compile("(\\s*for\\s*\\([^\\{]+\\)\\s*\\{)"), JS_INTERRUPTED_FUNCTION+"();"), // for with block
+      new PoisonPil(Pattern.compile("(\\s*for\\s*\\([^\\{]+\\)\\s*[^\\{]+;)"), JS_INTERRUPTED_FUNCTION+"();"), // for without block
+      new PoisonPil(Pattern.compile("(\\s*([^\"]?function[^\"])\\s*[^\\{]+\\{)"), JS_INTERRUPTED_FUNCTION+"();"), // function except when enclosed in quotes
       new PoisonPil(Pattern.compile("(\\s*while\\s*\\([^\\{]+\\{)"), JS_INTERRUPTED_FUNCTION+"();"),
       new PoisonPil(Pattern.compile("(\\s*do\\s*\\{)"), JS_INTERRUPTED_FUNCTION+"();")
     );


### PR DESCRIPTION
When processing complex scripts, e.g. containing browserified code, the sanitizer inserts teh interrupt checking function at wrong places and later fails to eval the secured js.
Example prefix:

`var browserify_require=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){`

will insert __if(); at 2 wrong places:
1) Due to matching on require=="function" (should only match on actual function)
2) Due to matching on for(var o=0;o<r.length;o++)s(r[o]);return s})({ (erroneously interpreting the last curly brace as the start of the for block which is brace-less though)

This PR adjusts the regexes for the interrupt-checking function injection to be more selective and also include brace-less for-loops. Surely there is more to be done (e.g. the sanitizer currently also injects __if(); inside comments if the 10th semicolon happens to be inside a comment) but it's prudent to be defensive with altering regexes so this can be improved incrementally after having been tested thoroughly.
cheers