### PR TITLE
Allow sandboxed Invocable::invoke*

### DIFF
--- a/src/main/java/delight/nashornsandbox/NashornSandbox.java
+++ b/src/main/java/delight/nashornsandbox/NashornSandbox.java
@@ -4,6 +4,7 @@ import java.io.Writer;
 import java.util.concurrent.ExecutorService;
 
 import javax.script.Bindings;
+import javax.script.Invocable;
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
 
@@ -245,5 +246,11 @@ public interface NashornSandbox {
    * @return
    */
   Bindings createBindings();
-  
+
+  /**
+   * Returns an {@link Invocable} instance, so that method invocations are also sandboxed.
+   * @return
+   */
+  Invocable getSandboxedInvocable();
+
 }

--- a/src/main/java/delight/nashornsandbox/internal/EvaluateOperation.java
+++ b/src/main/java/delight/nashornsandbox/internal/EvaluateOperation.java
@@ -1,0 +1,42 @@
+package delight.nashornsandbox.internal;
+
+import static delight.nashornsandbox.internal.NashornSandboxImpl.LOG;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+public class EvaluateOperation implements ScriptEngineOperation {
+
+	private final String js;
+	private final ScriptContext scriptContext;
+
+	public String getJs() {
+		return js;
+	}
+
+	public ScriptContext getScriptContext() {
+		return scriptContext;
+	}
+
+	public EvaluateOperation(String js, ScriptContext scriptContext) {
+		this.js = js;
+		this.scriptContext = scriptContext;
+	}
+
+	@Override
+	public Object executeScriptEngineOperation(ScriptEngine scriptEngine) throws ScriptException {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("--- Running JS ---");
+			LOG.debug(js);
+			LOG.debug("--- JS END ---");
+		}
+
+		if (scriptContext != null) {
+			return scriptEngine.eval(js, scriptContext);
+		} else {
+			return scriptEngine.eval(js);
+		}
+	}
+
+}

--- a/src/main/java/delight/nashornsandbox/internal/InvokeOperation.java
+++ b/src/main/java/delight/nashornsandbox/internal/InvokeOperation.java
@@ -1,0 +1,27 @@
+package delight.nashornsandbox.internal;
+
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+
+public class InvokeOperation implements ScriptEngineOperation {
+
+	private final Object thisObj;
+	private final String name;
+	private final Object[] args;
+
+	public InvokeOperation(Object thisObj, String name, Object[] args) {
+		this.thisObj = thisObj;
+		this.name = name;
+		this.args = args;
+	}
+
+	@Override
+	public Object executeScriptEngineOperation(ScriptEngine scriptEngine) throws Exception {
+		if  (thisObj == null) {
+			return ((Invocable)scriptEngine).invokeFunction(name, args);
+		} else {
+			return ((Invocable)scriptEngine).invokeMethod(thisObj, name, args);
+		}
+	}
+
+}

--- a/src/main/java/delight/nashornsandbox/internal/ScriptEngineOperation.java
+++ b/src/main/java/delight/nashornsandbox/internal/ScriptEngineOperation.java
@@ -1,0 +1,10 @@
+package delight.nashornsandbox.internal;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+public interface ScriptEngineOperation {
+
+	Object executeScriptEngineOperation(ScriptEngine scriptEngine) throws ScriptException, Exception;
+
+}

--- a/src/test/java/delight/nashornsandbox/TestInvocable.java
+++ b/src/test/java/delight/nashornsandbox/TestInvocable.java
@@ -1,0 +1,34 @@
+package delight.nashornsandbox;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.script.Invocable;
+import javax.script.ScriptException;
+
+import org.junit.Test;
+
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+
+public class TestInvocable {
+
+	@Test
+	public void testInvokeFunction() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
+		final NashornSandbox sandbox = NashornSandboxes.create();
+		final String script = "function x(){return 1;}\n";
+		sandbox.eval(script);
+		Invocable invocable = sandbox.getSandboxedInvocable();
+		assertEquals(1, invocable.invokeFunction("x"));
+	}
+
+	@Test
+	public void testInvokeMethod() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
+		final NashornSandbox sandbox = NashornSandboxes.create();
+		final String script = "var obj = {n: 1, x:function(arg){return this.n + arg;}};";
+		sandbox.eval(script);
+		Object thisobj = sandbox.get("obj");
+		Invocable invocable = sandbox.getSandboxedInvocable();
+
+		assertEquals(3.0, invocable.invokeMethod(thisobj, "x", 2));
+	}
+
+}


### PR DESCRIPTION
I need to invoke JS functions from Java using javax.script.Invocable, which must also be sandboxed. Therefore, I factored out the code needed for execution of ScriptEngine methods in a new thread and added getSandboxedInvocable() that transparently sandboxes the Invocable::invoke* methods. However, the Invocable::getInterface() methods are only stubs. They could be implemented in a similar fashion using object proxies, if somebody (or I) needs them in the future.
What do you think?