### PR TITLE
Use Executor instead of ExecutorService

### DIFF
--- a/src/main/java/delight/nashornsandbox/NashornSandbox.java
+++ b/src/main/java/delight/nashornsandbox/NashornSandbox.java
@@ -1,7 +1,7 @@
 package delight.nashornsandbox;
 
 import java.io.Writer;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 import javax.script.Bindings;
 import javax.script.Invocable;
@@ -55,12 +55,12 @@ public interface NashornSandbox {
   /**
    * Sets the maximum CPU time in milliseconds allowed for script execution.
    * <p>
-   *   Note, {@link ExecutorService} should be also set when time is set greater
+   *   Note, {@link Executor} should be also set when time is set greater
    *   than 0.
    * </p>
    *
    * @param limit time limit in miliseconds
-   * @see #setExecutor(ExecutorService)
+   * @see #setExecutor(Executor)
    */
   void setMaxCPUTime(long limit);
   
@@ -70,7 +70,7 @@ public interface NashornSandbox {
    *   Note, thread memory usage is only approximation.
    * </p>
    * <p>
-   *   Note, {@link ExecutorService} should be also set when memory limit is set
+   *   Note, {@link Executor} should be also set when memory limit is set
    *   greater than 0. Nashorn takes some memory at start, be generous and give
    *   at least 1MB.
    * </p>
@@ -98,14 +98,14 @@ public interface NashornSandbox {
    * @param executor the executor service
    * @see #setMaxCPUTime(long)
    */
-  void setExecutor(ExecutorService executor);
+  void setExecutor(Executor executor);
   
   /**
    * Gets the current executor service.
    *  
    * @return current executor service
    */
-  ExecutorService getExecutor();
+  Executor getExecutor();
   
   /**
    * Evaluates the JavaScript string.

--- a/src/main/java/delight/nashornsandbox/internal/JsEvaluator.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsEvaluator.java
@@ -1,12 +1,12 @@
 package delight.nashornsandbox.internal;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 import javax.script.ScriptEngine;
 
 /**
  * The JavaScript evaluator. It is designed to run Nashorn engine in separate
- * thread (using provided {@link ExecutorService}), to allow limit cpu time 
+ * thread (using provided {@link Executor}), to allow limit cpu time
  * consumed. 
  *
  * <p>Created on 2017.11.22</p>

--- a/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
@@ -1,7 +1,7 @@
 package delight.nashornsandbox.internal;
 
 import java.io.Writer;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 import javax.script.Bindings;
 import javax.script.Invocable;
@@ -47,7 +47,7 @@ public class NashornSandboxImpl implements NashornSandbox {
 	/** Maximum memory of executor thread used. */
 	protected long maxMemory = 0L;
 
-	protected ExecutorService executor;
+	protected Executor executor;
 
 	protected boolean allowPrintFunctions = false;
 
@@ -226,12 +226,12 @@ public class NashornSandboxImpl implements NashornSandbox {
 	}
 
 	@Override
-	public void setExecutor(final ExecutorService executor) {
+	public void setExecutor(final Executor executor) {
 		this.executor = executor;
 	}
 
 	@Override
-	public ExecutorService getExecutor() {
+	public Executor getExecutor() {
 		return executor;
 	}
 

--- a/src/test/java/delight/nashornsandbox/TestExceptions.java
+++ b/src/test/java/delight/nashornsandbox/TestExceptions.java
@@ -1,5 +1,6 @@
 package delight.nashornsandbox;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.script.ScriptException;
@@ -54,10 +55,11 @@ public class TestExceptions {
   @Test
   public void test_with_line_number() {
     NashornSandbox sandbox = null;
+    ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
       sandbox = NashornSandboxes.create();
       sandbox.setMaxCPUTime(5000);
-      sandbox.setExecutor(Executors.newSingleThreadExecutor());
+      sandbox.setExecutor(executor);
       final StringBuilder _builder = new StringBuilder();
       _builder.append("var in_the_first_line_all_good;\n");
       _builder.append("\t\t\t");
@@ -70,7 +72,7 @@ public class TestExceptions {
     } catch (final Throwable _t) {
       if (_t instanceof Throwable) {
         final Throwable t = _t;
-        sandbox.getExecutor().shutdown();
+        executor.shutdown();
         Assert.assertTrue(t.getMessage().contains("4"));
         return;
       } else {

--- a/src/test/java/delight/nashornsandbox/TestIfElse.java
+++ b/src/test/java/delight/nashornsandbox/TestIfElse.java
@@ -1,5 +1,6 @@
 package delight.nashornsandbox;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.script.ScriptException;
@@ -17,7 +18,8 @@ public class TestIfElse {
   public void testIfElse() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
     sandbox.setMaxCPUTime(500);
-    sandbox.setExecutor(Executors.newSingleThreadExecutor());
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    sandbox.setExecutor(executor);
     final StringBuilder _builder = new StringBuilder();
     _builder.append("if (true)\n");
     _builder.append("var x=1;\n");
@@ -38,6 +40,6 @@ public class TestIfElse {
     _builder_1.append("}\n");
     sandbox.eval(_builder_1.toString());
     Assert.assertEquals(Integer.valueOf(4), sandbox.eval("y"));
-    sandbox.getExecutor().shutdown();
+    executor.shutdown();
   }
 }

--- a/src/test/java/delight/nashornsandbox/TestIssue34.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue34.java
@@ -3,6 +3,7 @@ package delight.nashornsandbox;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.script.ScriptException;
@@ -19,6 +20,7 @@ public class TestIssue34 {
 
 	Logger logger;
 	NashornSandbox sandbox;
+	ExecutorService executor;
 
 	public static class Logger {
 
@@ -41,7 +43,8 @@ public class TestIssue34 {
 		sandbox.allowNoBraces(false);
 		sandbox.allowPrintFunctions(true);
 		sandbox.setMaxPreparedStatements(30);
-		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		executor = Executors.newSingleThreadExecutor();
+		sandbox.setExecutor(executor);
 		logger = new Logger();
 		sandbox.inject("logger", logger);
 	}
@@ -152,7 +155,7 @@ public class TestIssue34 {
 
 	@After
 	public void tearDown() {
-		sandbox.getExecutor().shutdown();
+		executor.shutdown();
 	}
 
 }

--- a/src/test/java/delight/nashornsandbox/TestIssue36.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue36.java
@@ -22,8 +22,8 @@ public class TestIssue36 {
 	        sandbox.setExecutor(executor);
 	        Boolean done = (Boolean) sandbox.eval("done = false;");
 	        Assert.assertFalse(done);
-	        
-	        sandbox.getExecutor().shutdown();
+
+		    executor.shutdown();
 	        
 	}
 	

--- a/src/test/java/delight/nashornsandbox/TestLimitCPU.java
+++ b/src/test/java/delight/nashornsandbox/TestLimitCPU.java
@@ -3,6 +3,7 @@ package delight.nashornsandbox;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.script.Invocable;
@@ -20,9 +21,10 @@ public class TestLimitCPU {
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		try {
 			sandbox.setMaxCPUTime(50);
-			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.setExecutor(executor);
 			final StringBuilder _builder = new StringBuilder();
 			_builder.append("var x = 1;\n");
 			_builder.append("while (true) {\n");
@@ -31,17 +33,18 @@ public class TestLimitCPU {
 			_builder.append("}\n");
 			sandbox.eval(_builder.toString());
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_evil_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		sandbox.setMaxCPUTime(50);
-		sandbox.setExecutor(Executors.newSingleThreadExecutor());
-		final String js = "var x = 1;\nwhile (true) { }\n";
+		sandbox.setExecutor(executor);
 		try {
+		final String js = "var x = 1;\nwhile (true) { }\n";
 			// try evaluate bad js
 			try {
 				sandbox.eval(js);
@@ -53,15 +56,16 @@ public class TestLimitCPU {
 			sandbox.allowNoBraces(true);
 			sandbox.eval(js);
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test
 	public void test_nice_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		sandbox.setMaxCPUTime(500);
-		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		sandbox.setExecutor(executor);
 		final StringBuilder _builder = new StringBuilder();
 		_builder.append("var x = 1;\n");
 		_builder.append("for (var i=0;i<=1000;i++) {\n");
@@ -69,104 +73,111 @@ public class TestLimitCPU {
 		_builder.append("x = x + i\n");
 		_builder.append("}\n");
 		sandbox.eval(_builder.toString());
-		sandbox.getExecutor().shutdown();
+		executor.shutdown();
 	}
 
 	@Test(expected = BracesException.class)
 	public void test_only_while() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		sandbox.setMaxCPUTime(50);
-		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		sandbox.setExecutor(executor);
 		try {
 			final String badScript = "while (true);\n";
 			sandbox.eval(badScript);
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_only_while_allowed_bad_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		sandbox.setMaxCPUTime(50);
 		
-		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		sandbox.setExecutor(executor);
 		try {
 			final String badScript = "while (true);\n";
 			sandbox.allowNoBraces(true);
 			sandbox.eval(badScript);
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_only_while_good_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		sandbox.setMaxCPUTime(50);
-		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		sandbox.setExecutor(executor);
 		try {
 			final String goodScript = "while (true); {i=1;}";
 			sandbox.allowNoBraces(true);
 			sandbox.eval(goodScript);
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test(expected = BracesException.class)
 	public void test_while_plus_iteration_bad_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		try {
 			sandbox.setMaxCPUTime(50);
-			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.setExecutor(executor);
 			final String badScirpt = "var x=0;\nwhile (true) x++;\n";
 			sandbox.eval(badScirpt);
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_while_plus_iteration_bad_scrip_allowed() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		try {
 			sandbox.setMaxCPUTime(50);
-			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.setExecutor(executor);
 			final String badScirpt = "var x=0;\nwhile (true) x++;\n";
 			sandbox.allowNoBraces(true);
 			sandbox.eval(badScirpt);
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_while_plus_iteration() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		try {
 			sandbox.setMaxCPUTime(50);
-			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.setExecutor(executor);
 			final String goodScript = "var x=0;\nwhile (true) {x++;}\n";
 			sandbox.eval(goodScript);
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_do_while() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		try {
 			sandbox.setMaxCPUTime(50);
-			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.setExecutor(executor);
 			final StringBuilder _builder = new StringBuilder();
 			_builder.append("do {\n");
 			_builder.append("\t\n");
 			_builder.append("} while (true);\n");
 			sandbox.eval(_builder.toString());
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 
@@ -180,11 +191,12 @@ public class TestLimitCPU {
 		for (int i = 0; i < 20; i++) {
 
 			NashornSandbox sandbox = NashornSandboxes.create();
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 			sandbox.setMaxCPUTime(100); // in millis
 			sandbox.setMaxMemory(1000 * 1000); // 1 MB
 			sandbox.allowNoBraces(false);
 			sandbox.setMaxPreparedStatements(30);
-			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.setExecutor(executor);
 			Exception exp = null;
 			try {
 
@@ -194,7 +206,7 @@ public class TestLimitCPU {
 
 				exp = e;
 			}
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 			Assert.assertNotNull(exp);
 		}
 	}
@@ -202,8 +214,9 @@ public class TestLimitCPU {
 	@Test
 	public void testCpuLmitInInvocable() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
 		sandbox.setMaxCPUTime(50);
-		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		sandbox.setExecutor(executor);
 		try {
 			final String badScript = "function x(){while (true){};}\n";
 			try {
@@ -219,7 +232,7 @@ public class TestLimitCPU {
 				assertEquals(ScriptCPUAbuseException.class, e.getCause().getClass());
 			}
 		} finally {
-			sandbox.getExecutor().shutdown();
+			executor.shutdown();
 		}
 	}
 }

--- a/src/test/java/delight/nashornsandbox/TestMemoryLimit.java
+++ b/src/test/java/delight/nashornsandbox/TestMemoryLimit.java
@@ -4,6 +4,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.script.ScriptException;
@@ -28,9 +29,10 @@ public class TestMemoryLimit {
     @Test
     public void test() throws ScriptCPUAbuseException, ScriptException {
       final NashornSandbox sandbox = NashornSandboxes.create();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
       try {
         sandbox.setMaxMemory(MEMORY_LIMIT);
-        sandbox.setExecutor(Executors.newSingleThreadExecutor());
+        sandbox.setExecutor(executor);
         final String js = "var o={},i=0; while (true) {o[i++] = 'abc'}";
         sandbox.eval(js);
         fail("Exception should be thrown");
@@ -39,31 +41,33 @@ public class TestMemoryLimit {
         assertFalse(e.isScriptKilled());
       }
       finally {
-        sandbox.getExecutor().shutdown();
+        executor.shutdown();
       }
     }
     
     @Test(expected=BracesException.class)
     public void test_noexpectedbraces() throws ScriptCPUAbuseException, ScriptException {
       final NashornSandbox sandbox = NashornSandboxes.create();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
       try {
         sandbox.setMaxMemory(MEMORY_LIMIT);
-        sandbox.setExecutor(Executors.newSingleThreadExecutor());
+        sandbox.setExecutor(executor);
         final String js = "var o={},i=0; while (true) o[i++] = 'abc'";
         sandbox.eval(js);
         fail("Exception should be thrown");
       }
       finally {
-        sandbox.getExecutor().shutdown();
+        executor.shutdown();
       }
     }
 
     @Test
     public void test_killed() throws ScriptCPUAbuseException, ScriptException {
       final NashornSandbox sandbox = NashornSandboxes.create();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
       try {
         sandbox.setMaxMemory(MEMORY_LIMIT);
-        sandbox.setExecutor(Executors.newSingleThreadExecutor());
+        sandbox.setExecutor(executor);
         sandbox.allowNoBraces(true);
         final String js = "var o={},i=0; while (true) o[i++] = 'abc'";
         sandbox.eval(js);
@@ -73,16 +77,17 @@ public class TestMemoryLimit {
         assertTrue(e.isScriptKilled());
       }
       finally {
-        sandbox.getExecutor().shutdown();
+        executor.shutdown();
       }
     }
 
     @Test
     public void test_no_abuse() throws ScriptCPUAbuseException, ScriptException {
       final NashornSandbox sandbox = NashornSandboxes.create();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
       try {
         sandbox.setMaxMemory(MEMORY_LIMIT);
-        sandbox.setExecutor(Executors.newSingleThreadExecutor());
+        sandbox.setExecutor(executor);
         final String js = "var o={},i=0; while(i<10) {o[i++] = 'abc';}";
         sandbox.eval(js);
       }
@@ -90,7 +95,7 @@ public class TestMemoryLimit {
         fail("No exception should be thrown");
       }
       finally {
-        sandbox.getExecutor().shutdown();
+        executor.shutdown();
       }
     }
     

--- a/src/test/java/delight/nashornsandbox/TestScriptInterruptionAndCatch.java
+++ b/src/test/java/delight/nashornsandbox/TestScriptInterruptionAndCatch.java
@@ -1,5 +1,6 @@
 package delight.nashornsandbox;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.script.ScriptException;
@@ -15,9 +16,10 @@ public class TestScriptInterruptionAndCatch {
   @Test(expected = ScriptCPUAbuseException.class)
   public void test_catch() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
+    ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
       sandbox.setMaxCPUTime(50);
-      sandbox.setExecutor(Executors.newSingleThreadExecutor());
+      sandbox.setExecutor(executor);
       final StringBuilder _builder = new StringBuilder();
       _builder.append("try {\n");
       _builder.append("\t");
@@ -34,7 +36,7 @@ public class TestScriptInterruptionAndCatch {
       _builder.append("}\n");
       sandbox.eval(_builder.toString());
     } finally {
-      sandbox.getExecutor().shutdown();
+      executor.shutdown();
     }
   }
 }

--- a/src/test/java/delight/nashornsandbox/TestSwitch.java
+++ b/src/test/java/delight/nashornsandbox/TestSwitch.java
@@ -1,5 +1,6 @@
 package delight.nashornsandbox;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.script.ScriptException;
@@ -15,10 +16,11 @@ public class TestSwitch {
   @Test
   public void test() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
+    ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
       sandbox.allowPrintFunctions(true);
       sandbox.setMaxCPUTime(50);
-      sandbox.setExecutor(Executors.newSingleThreadExecutor());
+      sandbox.setExecutor(executor);
       final StringBuilder _builder = new StringBuilder();
       _builder.append("var expr = \"one\";\n\n");
       _builder.append("switch (expr) {\n");
@@ -41,7 +43,7 @@ public class TestSwitch {
       _builder.append("}\n\n");
       sandbox.eval(_builder.toString());
     } finally {
-      sandbox.getExecutor().shutdown();
+      executor.shutdown();
     }
   }
 }


### PR DESCRIPTION
The goal of this PR is to loosen the conditions on the `executor` for better interoperability by making it an `Executor` instead of an `ExecutorService`. 

This is a breaking change but it does not have any functional change.