### PR TITLE
Fix for issue #55: ThreadMonitor waits unnecessarily

### DIFF
--- a/src/main/java/delight/nashornsandbox/internal/ThreadMonitor.java
+++ b/src/main/java/delight/nashornsandbox/internal/ThreadMonitor.java
@@ -83,7 +83,9 @@ public class ThreadMonitor {
 		try {
 			// wait, for threadToMonitor to be set in JS evaluator thread
 			synchronized (monitor) {
-				monitor.wait(maxCPUTime / MILI_TO_NANO);
+				if (threadToMonitor == null) {
+					monitor.wait(maxCPUTime / MILI_TO_NANO);
+				}
 			}
 			if (threadToMonitor == null) {
 				throw new IllegalStateException("Executor thread not set after " + maxCPUTime / MILI_TO_NANO + " ms");

--- a/src/test/java/delight/nashornsandbox/internal/ThreadMonitorTest.java
+++ b/src/test/java/delight/nashornsandbox/internal/ThreadMonitorTest.java
@@ -1,0 +1,26 @@
+package delight.nashornsandbox.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * JUnit test for ThreadMonitor.
+ */
+public class ThreadMonitorTest {
+
+	/**
+	 * This is a simple test that verifies that if the thread to monitor is already set, the ThreadMonitor does not
+	 * wait unnecessarily when it is run.
+	 */
+	@Test
+	public void when_run_and_threadToMonitor_set_then_do_not_wait() {
+		final ThreadMonitor threadMonitor = new ThreadMonitor(1000, 0);
+		Thread threadToMonitor = new Thread();
+		threadMonitor.setThreadToMonitor(threadToMonitor);
+		threadMonitor.stopMonitor();
+
+		long startTime = System.currentTimeMillis();
+		threadMonitor.run();
+		Assert.assertTrue(System.currentTimeMillis() - startTime < 500);
+	}
+}


### PR DESCRIPTION
This change provides a fix and test for issue #55:
https://github.com/javadelight/delight-nashorn-sandbox/issues/55

In ThreadMonitor in the call to wait on the monitor object. It's
possible that the threadToMonitor was already set and the monitor
notification sent. In that case, the monitor wait goes to the
maximum value for the cpu time limit.

The fix is to first verify that the threadToMonitor is null within
the synchronized block and before the wait on the monitor.