### PR TITLE
Make secured js cache replaceable

### DIFF
--- a/src/main/java/delight/nashornsandbox/NashornSandbox.java
+++ b/src/main/java/delight/nashornsandbox/NashornSandbox.java
@@ -278,4 +278,10 @@ public interface NashornSandbox {
    */
   Invocable getSandboxedInvocable();
 
+  /**
+   * Overwrites the cache for pre-processed javascript. Must be called before the first invocation of {@link #eval(String)}
+   * and its overloads.
+   * @param cache the new cache to use
+   */
+  void setScriptCache(SecuredJsCache cache);
 }

--- a/src/main/java/delight/nashornsandbox/SecuredJsCache.java
+++ b/src/main/java/delight/nashornsandbox/SecuredJsCache.java
@@ -1,0 +1,21 @@
+package delight.nashornsandbox;
+
+import java.util.function.Supplier;
+
+/**
+ * A cache used to store pre-processed javascript strings, which can be used to share
+ * these among different {@link NashornSandbox}es. The interface provides a facility
+ * to implement concurrent caches, but the actual thread safety is at
+ * the implementor's discretion.
+ *
+ */
+public interface SecuredJsCache {
+	/**
+	 * Gets a value from the cache and tries to create it if it couldn't be found.
+	 * @param js the raw javascript code
+	 * @param allowNoBraces whether missing braces are allowed.
+	 * @param producer if no cached value could be found, this is used to create the value
+	 * @return the cached or created value, or null if it could be neither found in the cache nor created.
+	 */
+	public String getOrCreate(String js, boolean allowNoBraces, Supplier<String> producer);
+}

--- a/src/main/java/delight/nashornsandbox/internal/LinkedHashMapSecuredJsCache.java
+++ b/src/main/java/delight/nashornsandbox/internal/LinkedHashMapSecuredJsCache.java
@@ -1,0 +1,40 @@
+package delight.nashornsandbox.internal;
+
+import java.util.LinkedHashMap;
+import java.util.function.Supplier;
+
+import delight.nashornsandbox.SecuredJsCache;
+
+/**
+ * Default implementation of {@link SecuredJsCache}, uses a {@link LinkedHashMap}
+ * as its cache and is not thread-safe. Also, mixing scripts with missing braces
+ * allowed and not allowed is forbidden.
+ */
+class LinkedHashMapSecuredJsCache implements SecuredJsCache {
+
+	private final LinkedHashMap<String, String> map;
+	private final boolean allowNoBraces;
+
+	public LinkedHashMapSecuredJsCache(LinkedHashMap<String, String> linkedHashMap, boolean allowNoBraces) {
+		this.map = linkedHashMap;
+		this.allowNoBraces = allowNoBraces;
+	}
+
+	@Override
+	public String getOrCreate(String js, boolean allowNoBraces, Supplier<String> producer) {
+		assertConfiguration(allowNoBraces);
+		String result = map.get(js);
+		if (result == null) {
+			result = producer.get();
+			map.put(js, result);
+		}
+		return result;
+	}
+
+	private void assertConfiguration(boolean allowNoBraces) {
+		if (allowNoBraces != this.allowNoBraces) {
+			throw new IllegalArgumentException("Non-matching cache configuration");
+		}
+	}
+
+}

--- a/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import delight.nashornsandbox.NashornSandbox;
+import delight.nashornsandbox.SecuredJsCache;
 import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 import delight.nashornsandbox.exceptions.ScriptMemoryAbuseException;
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
@@ -71,6 +72,8 @@ public class NashornSandboxImpl implements NashornSandbox {
 
 	/** The size of the LRU cache of prepared statemensts. */
 	protected int maxPreparedStatements;
+
+	protected SecuredJsCache suppliedCache;
 
 	public NashornSandboxImpl() {
 		this(new String[0]);
@@ -208,7 +211,11 @@ public class NashornSandboxImpl implements NashornSandbox {
 
 	JsSanitizer getSanitizer() {
 		if (sanitizer == null) {
-			sanitizer = new JsSanitizer(scriptEngine, maxPreparedStatements, allowNoBraces);
+			if (suppliedCache == null) {
+				sanitizer = new JsSanitizer(scriptEngine, maxPreparedStatements, allowNoBraces);
+			} else {
+				sanitizer = new JsSanitizer(scriptEngine, allowNoBraces, suppliedCache);
+			}
 		}
 		return sanitizer;
 	}
@@ -375,6 +382,11 @@ public class NashornSandboxImpl implements NashornSandbox {
 			lazyInvocable = sandboxInvocable;
 		}
 		return lazyInvocable;
+	}
+
+	@Override
+	public void setScriptCache(SecuredJsCache cache) {
+		this.suppliedCache = cache;
 	}
 
 }

--- a/src/test/java/delight/nashornsandbox/TestCustomCache.java
+++ b/src/test/java/delight/nashornsandbox/TestCustomCache.java
@@ -1,0 +1,49 @@
+package delight.nashornsandbox;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Supplier;
+
+import javax.script.ScriptException;
+
+import org.junit.Test;
+
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+
+public class TestCustomCache {
+	public static class CustomCache implements SecuredJsCache {
+
+		private boolean consulted = false;
+		private String produced;
+		private String source;
+
+		@Override
+		public String getOrCreate(String js, boolean allowNoBraces, Supplier<String> producer) {
+			consulted = true;
+			source = js;
+			produced = producer.get();
+			return "void(0);";
+		}
+	}
+
+	@Test
+	public void testCustomCacheUsage() throws ScriptCPUAbuseException, ScriptException {
+		NashornSandbox sb = NashornSandboxes.create();
+		final CustomCache cache = new CustomCache();
+		sb.setScriptCache(cache);
+		Object result = sb.eval("5 ;");
+
+		assertTrue(cache.consulted);
+		assertNull(result);
+		assertEquals("5 ;", cache.source);
+
+		// In case this fails because of changes to the beautify-routine:
+		// The actual value is not that important, this is just
+		// a plausibility check to determine whether "producer"
+		// has been passed correctly to the cache's getOrCreate()
+		// method.
+		assertEquals("5;", cache.produced);
+	}
+}


### PR DESCRIPTION
The secured js cache is currently only available per NashornSandbox instance. I have many Sandbox instances, all executing the same script in separate threads, which is effectively beautified on every request. This makes processing very slow for me.

In this pull request, I abstracted out an interface for that cache, so that I can replace it with my own global & thread-safe implementation. However, as concurrent caching is nontrivial and requires additional dependencies, I chose not to include my own concrete implementation of that cache.