### PR TITLE
[BUG_FIX]: Executor thread not set after <some value> ms - intermitte…

### DIFF
--- a/src/main/java/delight/nashornsandbox/internal/ThreadMonitor.java
+++ b/src/main/java/delight/nashornsandbox/internal/ThreadMonitor.java
@@ -84,7 +84,7 @@ public class ThreadMonitor {
 			// wait, for threadToMonitor to be set in JS evaluator thread
 			synchronized (monitor) {
 				if (threadToMonitor == null) {
-					monitor.wait(maxCPUTime / MILI_TO_NANO);
+					monitor.wait((maxCPUTime + 100) / MILI_TO_NANO);
 				}
 			}
 			if (threadToMonitor == null) {


### PR DESCRIPTION
Executor thread not set after <some value> ms - intermittently #75

> Fixed issue my adding additional 100ms delay to get the thread monitor instance after force kill