### PR TITLE
issue #74 PoisonPill regex fix

### DIFF
--- a/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
@@ -72,7 +72,7 @@ class JsSanitizer {
 
 	private final static List<PoisonPil> POISON_PILLS = Arrays.asList(
 			// every 10th statements ended with semicolon put interrupt checking function
-			new PoisonPil(Pattern.compile("(([^;]+;){9}[^;]+(?<!break|continue);)\\n"),
+			new PoisonPil(Pattern.compile("(([^;]+;){9}[^;]+(?<!break|continue);\\n(?![\\W]*(\\/\\/.+[\\W]+)*else))"),
 					JS_INTERRUPTED_FUNCTION + "();\n"),
 			// every (except switch) block start brace put interrupt checking function
 			new PoisonPil(Pattern.compile("(\\s*for\\s*\\([^\\{]+\\)\\s*\\{)"), JS_INTERRUPTED_FUNCTION + "();"), // for


### PR DESCRIPTION
Here is a fix for Issue [#74](https://github.com/javadelight/delight-nashorn-sandbox/issues/74)

My original suggestion was not a durable as I thought so I changed the regex look ahead to dispense with possible comments and white space before the enclosing else statement. 