### PR TITLE
Support for GraalJS engine #85

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -10,6 +10,7 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
@@ -25,6 +26,7 @@
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -2,4 +2,5 @@ eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,26 @@
 			<version>1.6.12</version>
 		</dependency>
 
+                <dependency>
+                    <groupId>org.graalvm.js</groupId>
+                    <artifactId>js-scriptengine</artifactId>
+                    <version>1.0.0-rc15</version>
+                </dependency>
+<dependency>
+    <groupId>org.graalvm.truffle</groupId>
+    <artifactId>truffle-api</artifactId>
+    <version>1.0.0-rc15</version> <!-- or any later version -->
+</dependency>
+                <dependency>
+                    <groupId>org.graalvm.sdk</groupId>
+                    <artifactId>graal-sdk</artifactId>
+                    <version>1.0.0-rc15</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.graalvm.js</groupId>
+                    <artifactId>js</artifactId>
+                    <version>1.0.0-rc15</version>
+                </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/main/java/delight/nashornsandbox/GraalSandboxes.java
+++ b/src/main/java/delight/nashornsandbox/GraalSandboxes.java
@@ -4,38 +4,16 @@ import delight.nashornsandbox.internal.GraalSandboxImpl;
 import delight.nashornsandbox.internal.NashornSandboxImpl;
 
 /**
- * The Nashorn sandbox factory.
- *
- * <p>
- * Created on 2015-08-07
- * </p>
- * 
- * @author <a href="mailto:mxro@nowhere.com">mxro</a>
- * @version $Id$
+ * The Nashorn sandbox factory for GraalJS
+ * @author marcoellwanger
  */
-@SuppressWarnings("all")
 public class GraalSandboxes {
 	
-	/**
-	 * <p>Creates a new sandbox instance.
-	 * 
-	 * @return The newly created sandbox instance.
-	 */
 	public static NashornSandbox create() {
 		return new GraalSandboxImpl();
 	}
 	
-	/**
-	 * <p>Create a sandbox while supplying arguments for the engine such as '--no-java'.
-	 * <p>More information on available parameters can be found in the following:
-	 * <ul>
-	 * <li><a href='http://hg.openjdk.java.net/jdk8/jdk8/nashorn/file/tip/docs/DEVELOPER_README'>Nashorn DEVELOPER README</a></li>
-	 * <li><a href='https://github.com/JetBrains/jdk8u_nashorn/blob/master/src/jdk/nashorn/internal/runtime/resources/Options.properties'>Source Code Options.properties</a></li>
-	 * <ul>
-	 * @param args Options for initializing the Nashorn engine.
-	 * @return A newly created sandbox instance.
-	 */
 	public static NashornSandbox create(String... args) {
-		return new NashornSandboxImpl(args);
+		return new GraalSandboxImpl(args);
 	}
 }

--- a/src/main/java/delight/nashornsandbox/GraalSandboxes.java
+++ b/src/main/java/delight/nashornsandbox/GraalSandboxes.java
@@ -1,0 +1,41 @@
+package delight.nashornsandbox;
+
+import delight.nashornsandbox.internal.GraalSandboxImpl;
+import delight.nashornsandbox.internal.NashornSandboxImpl;
+
+/**
+ * The Nashorn sandbox factory.
+ *
+ * <p>
+ * Created on 2015-08-07
+ * </p>
+ * 
+ * @author <a href="mailto:mxro@nowhere.com">mxro</a>
+ * @version $Id$
+ */
+@SuppressWarnings("all")
+public class GraalSandboxes {
+	
+	/**
+	 * <p>Creates a new sandbox instance.
+	 * 
+	 * @return The newly created sandbox instance.
+	 */
+	public static NashornSandbox create() {
+		return new GraalSandboxImpl();
+	}
+	
+	/**
+	 * <p>Create a sandbox while supplying arguments for the engine such as '--no-java'.
+	 * <p>More information on available parameters can be found in the following:
+	 * <ul>
+	 * <li><a href='http://hg.openjdk.java.net/jdk8/jdk8/nashorn/file/tip/docs/DEVELOPER_README'>Nashorn DEVELOPER README</a></li>
+	 * <li><a href='https://github.com/JetBrains/jdk8u_nashorn/blob/master/src/jdk/nashorn/internal/runtime/resources/Options.properties'>Source Code Options.properties</a></li>
+	 * <ul>
+	 * @param args Options for initializing the Nashorn engine.
+	 * @return A newly created sandbox instance.
+	 */
+	public static NashornSandbox create(String... args) {
+		return new NashornSandboxImpl(args);
+	}
+}

--- a/src/main/java/delight/nashornsandbox/internal/GraalSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/GraalSandboxImpl.java
@@ -1,0 +1,57 @@
+package delight.nashornsandbox.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.SimpleScriptContext;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Context.Builder;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.PolyglotAccess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.oracle.truffle.js.scriptengine.GraalJSEngineFactory;
+import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
+
+
+/**
+ * Nashorn sandbox implementation for GraalJS
+ * @author marcoellwanger
+ */
+public class GraalSandboxImpl extends NashornSandboxImpl {
+
+	static final Logger LOG = LoggerFactory.getLogger(GraalSandboxImpl.class);
+	
+	public GraalSandboxImpl() {
+		this(new String[0]);
+	}
+	
+	public GraalSandboxImpl(String... params) {
+		super(GraalJSScriptEngine.create(null, Context.newBuilder().allowExperimentalOptions(true).allowPolyglotAccess(PolyglotAccess.ALL).allowHostAccess(HostAccess.ALL)), params);
+		Bindings bindings = this.scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
+		bindings.put("polyglot.js.allowHostClassLookup", (Predicate<String>) s -> this.sandboxClassFilter.getStringCache().contains(s));
+	}
+	
+	@Override
+	protected void resetEngineBindings() {
+		
+    }
+	
+	@Override
+	public void allow(final Class<?> clazz) {
+		super.allow(clazz);
+		resetEngineBindings();
+	}
+	
+	@Override
+	public void disallow(final Class<?> clazz) {
+		super.disallow(clazz);
+		resetEngineBindings();
+	}
+}

--- a/src/main/java/delight/nashornsandbox/internal/GraalSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/GraalSandboxImpl.java
@@ -1,23 +1,22 @@
 package delight.nashornsandbox.internal;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
-import javax.script.SimpleScriptContext;
+import javax.script.ScriptException;
 
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Context.Builder;
-import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.PolyglotAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.oracle.truffle.js.scriptengine.GraalJSEngineFactory;
 import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
+
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 
 /**
@@ -28,12 +27,15 @@ public class GraalSandboxImpl extends NashornSandboxImpl {
 
 	static final Logger LOG = LoggerFactory.getLogger(GraalSandboxImpl.class);
 	
+	public final boolean isStrict;
+	
 	public GraalSandboxImpl() {
 		this(new String[0]);
 	}
 	
 	public GraalSandboxImpl(String... params) {
 		super(GraalJSScriptEngine.create(null, Context.newBuilder().allowExperimentalOptions(true).allowPolyglotAccess(PolyglotAccess.ALL).allowHostAccess(HostAccess.ALL)), params);
+		isStrict = Arrays.asList(params).contains("-strict");
 		Bindings bindings = this.scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
 		bindings.put("polyglot.js.allowHostClassLookup", (Predicate<String>) s -> this.sandboxClassFilter.getStringCache().contains(s));
 	}
@@ -44,14 +46,82 @@ public class GraalSandboxImpl extends NashornSandboxImpl {
     }
 	
 	@Override
-	public void allow(final Class<?> clazz) {
-		super.allow(clazz);
-		resetEngineBindings();
+	public Bindings createBindings() {
+		return scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
 	}
 	
+    protected void produceSecureBindings() {
+        try {
+            final StringBuilder sb = new StringBuilder();
+            cached = scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
+            sanitizeBindings(cached);
+            if (!allowExitFunctions) {
+                sb.append("var quit=function(){};var exit=function(){};");
+            }
+            if (!allowPrintFunctions) {
+                sb.append("var print=function(){};var echo = function(){};");
+            }
+            if (!allowReadFunctions) {
+                sb.append("var readFully=function(){};").append("var readLine=function(){};");
+            }
+            if (!allowLoadFunctions) {
+                sb.append("var load=function(){};var loadWithNewGlobal=function(){};");
+            }
+            if (!allowGlobalsObjects) {
+                // Max 22nd of Feb 2018: I don't think these are strictly necessary since they are only available in scripting mode
+                sb.append("var $ARG=null;var $ENV=null;var $EXEC=null;");
+                sb.append("var $OPTIONS=null;var $OUT=null;var $ERR=null;var $EXIT=null;");
+            }
+            scriptEngine.eval(sb.toString());
+            this.engineAsserted = true;
+        }
+        catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Override
+	protected Bindings secureBindings(Bindings bindings) {
+        if (bindings == null)
+            return null;
+
+        if (bindings != cached) {
+        	for (Map.Entry<String, Object> entry : bindings.entrySet()) {
+        	  cached.putIfAbsent(entry.getKey(), entry.getValue());
+        	}
+        } else { 
+        	cached.putAll(bindings);
+        }
+        return cached;
+    }
+    
 	@Override
-	public void disallow(final Class<?> clazz) {
-		super.disallow(clazz);
-		resetEngineBindings();
+	public Object eval(final String js, final ScriptContext scriptContext, final Bindings bindings)
+			throws ScriptCPUAbuseException, ScriptException {
+		if (scriptContext != null) {
+			Bindings engineBindings = scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
+			Bindings contextBindings = scriptContext.getBindings(ScriptContext.ENGINE_SCOPE);
+			if (contextBindings != null) {
+				for (String key : contextBindings.keySet()) {
+					if (engineBindings.get(key) != null) contextBindings.remove(key);
+				}			
+			}
+		}
+	    produceSecureBindings(); // We need this here for bindings
+		final JsSanitizer sanitizer = getSanitizer();
+		// see https://github.com/javadelight/delight-nashorn-sandbox/issues/73
+		final String blockAccessToEngine = "Object.defineProperty(this, 'engine', {});" + 
+        		"Object.defineProperty(this, 'context', {});delete this.__noSuchProperty__;";
+		final String securedJs;
+		if (scriptContext == null) {
+			securedJs = blockAccessToEngine+sanitizer.secureJs(js);
+		} else {
+			// Unfortunately, blocking access to the engine property inteferes with setting a script context
+			// needs further investigation
+			securedJs = sanitizer.secureJs(js);
+		}
+        final Bindings securedBindings = secureBindings(bindings);
+        EvaluateOperation op = new EvaluateOperation(isStrict ? "'use strict';" + securedJs : securedJs, scriptContext, securedBindings);
+        return executeSandboxedOperation(op);
 	}
 }

--- a/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
@@ -2,7 +2,6 @@ package delight.nashornsandbox.internal;
 
 import java.io.Writer;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Supplier;
 
 import javax.script.Bindings;
 import javax.script.Invocable;
@@ -125,7 +124,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         return true;
     }
 
-    protected void produceSecureBindings() {
+    void produceSecureBindings() {
         try {
             if (!engineAsserted) {
                 final StringBuilder sb = new StringBuilder();
@@ -160,14 +159,14 @@ public class NashornSandboxImpl implements NashornSandbox {
         }
     }
 
-    protected void resetEngineBindings() {
+    void resetEngineBindings() {
         final Bindings bindings = createBindings();
         sanitizeBindings(bindings);
         bindings.putAll(cached);
         scriptEngine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
     }
 
-    protected void sanitizeBindings(Bindings bindings) {
+    void sanitizeBindings(Bindings bindings) {
         if (!allowExitFunctions) {
             bindings.remove("quit");
             bindings.remove("exit");
@@ -222,7 +221,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         return executeSandboxedOperation(op);
 	}
 
-	protected Bindings secureBindings(Bindings bindings) {
+	Bindings secureBindings(Bindings bindings) {
         if (bindings == null)
             return null;
 
@@ -231,7 +230,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         return bindings;
     }
 
-	protected Object executeSandboxedOperation(ScriptEngineOperation op) throws ScriptCPUAbuseException, ScriptException {
+	Object executeSandboxedOperation(ScriptEngineOperation op) throws ScriptCPUAbuseException, ScriptException {
         assertScriptEngine();
 		try {
 			if (maxCPUTime == 0 && maxMemory == 0) {

--- a/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
@@ -2,6 +2,7 @@ package delight.nashornsandbox.internal;
 
 import java.io.Writer;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import javax.script.Bindings;
 import javax.script.Invocable;
@@ -41,7 +42,7 @@ public class NashornSandboxImpl implements NashornSandbox {
 
 	static final Logger LOG = LoggerFactory.getLogger(NashornSandbox.class);
 
-	protected final SandboxClassFilter sandboxClassFilter;
+	protected final SandboxClassFilter sandboxClassFilter = new SandboxClassFilter();
 
 	protected final ScriptEngine scriptEngine;
 
@@ -83,20 +84,19 @@ public class NashornSandboxImpl implements NashornSandbox {
 	public NashornSandboxImpl() {
 		this(new String[0]);
 	}
-	
+
 	public NashornSandboxImpl(String... params) {
-		this.maxPreparedStatements = 0;
-		this.sandboxClassFilter = new SandboxClassFilter();
-		final NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
-		
+		this(null, params);
+	}
+
+	public NashornSandboxImpl(ScriptEngine engine, String... params) {
 		for (String param : params) {
 			if (param.equals("--no-java")) {
 				throw new IllegalArgumentException("The engine parameter --no-java is not supported. Using it would interfere with the injected code to test for infinite loops.");
 			}
 		}
-		
-		this.scriptEngine = factory.getScriptEngine(params, this.getClass().getClassLoader(), this.sandboxClassFilter);
-		
+		this.scriptEngine = engine == null ? new NashornScriptEngineFactory().getScriptEngine(params, this.getClass().getClassLoader(), this.sandboxClassFilter) : engine;
+		this.maxPreparedStatements = 0;
 		this.allow(InterruptTest.class);
 	}
 
@@ -160,7 +160,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         }
     }
 
-    private void resetEngineBindings() {
+    protected void resetEngineBindings() {
         final Bindings bindings = createBindings();
         sanitizeBindings(bindings);
         bindings.putAll(cached);
@@ -461,5 +461,4 @@ public class NashornSandboxImpl implements NashornSandbox {
 	public void setScriptCache(SecuredJsCache cache) {
 		this.suppliedCache = cache;
 	}
-
 }

--- a/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
@@ -125,7 +125,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         return true;
     }
 
-    private void produceSecureBindings() {
+    protected void produceSecureBindings() {
         try {
             if (!engineAsserted) {
                 final StringBuilder sb = new StringBuilder();
@@ -167,7 +167,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         scriptEngine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
     }
 
-    private void sanitizeBindings(Bindings bindings) {
+    protected void sanitizeBindings(Bindings bindings) {
         if (!allowExitFunctions) {
             bindings.remove("quit");
             bindings.remove("exit");
@@ -222,7 +222,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         return executeSandboxedOperation(op);
 	}
 
-	private Bindings secureBindings(Bindings bindings) {
+	protected Bindings secureBindings(Bindings bindings) {
         if (bindings == null)
             return null;
 
@@ -231,7 +231,7 @@ public class NashornSandboxImpl implements NashornSandbox {
         return bindings;
     }
 
-	private Object executeSandboxedOperation(ScriptEngineOperation op) throws ScriptCPUAbuseException, ScriptException {
+	protected Object executeSandboxedOperation(ScriptEngineOperation op) throws ScriptCPUAbuseException, ScriptException {
         assertScriptEngine();
 		try {
 			if (maxCPUTime == 0 && maxMemory == 0) {

--- a/src/main/java/delight/nashornsandbox/internal/SandboxClassFilter.java
+++ b/src/main/java/delight/nashornsandbox/internal/SandboxClassFilter.java
@@ -1,5 +1,6 @@
 package delight.nashornsandbox.internal;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -49,4 +50,7 @@ class SandboxClassFilter implements ClassFilter {
     stringCache = new HashSet<>();
   }
   
+  public Set<String> getStringCache() {
+	  return Collections.unmodifiableSet(stringCache);
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestAccessFunction.java
+++ b/src/test/java/delight/nashornsandbox/TestAccessFunction.java
@@ -1,5 +1,7 @@
 package delight.nashornsandbox;
 
+import java.util.function.Function;
+
 import javax.script.ScriptException;
 
 import org.junit.Assert;
@@ -12,6 +14,7 @@ import jdk.nashorn.api.scripting.ScriptObjectMirror;
 
 @SuppressWarnings("all")
 public class TestAccessFunction {
+
   @Test
   public void test_access_variable() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
@@ -20,5 +23,15 @@ public class TestAccessFunction {
     Assert.assertEquals(Integer.valueOf(42), ((ScriptObjectMirror) _get).call(this));
     final Object _eval = sandbox.eval("callMe");
     Assert.assertEquals(Integer.valueOf(42), ((ScriptObjectMirror) _eval).call(this));
+  }
+
+  @Test
+  public void test_access_variable_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.eval("function callMe() { return 42; };");
+    final Object _get = sandbox.get("callMe");
+    Assert.assertEquals(Integer.valueOf(42), ((Function<Object[], Object>) _get).apply(null));
+    final Object _eval = sandbox.eval("callMe");
+    Assert.assertEquals(Integer.valueOf(42), ((Function<Object[], Object>) _eval).apply(null));
   }
 }

--- a/src/test/java/delight/nashornsandbox/TestAllowAccess.java
+++ b/src/test/java/delight/nashornsandbox/TestAllowAccess.java
@@ -10,9 +10,17 @@ import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 @SuppressWarnings("all")
 public class TestAllowAccess {
+
   @Test
   public void test_file() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
+    sandbox.allow(File.class);
+    sandbox.eval("var File = Java.type('java.io.File'); File;");
+  }
+
+  @Test
+  public void test_file_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
     sandbox.allow(File.class);
     sandbox.eval("var File = Java.type('java.io.File'); File;");
   }

--- a/src/test/java/delight/nashornsandbox/TestAllowAndDisallowClasses.java
+++ b/src/test/java/delight/nashornsandbox/TestAllowAndDisallowClasses.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import javax.script.ScriptException;
 
+import org.graalvm.polyglot.PolyglotException;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,6 +14,7 @@ import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 @SuppressWarnings("all")
 public class TestAllowAndDisallowClasses {
+
   @Test
   public void test_file() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
@@ -39,6 +42,39 @@ public class TestAllowAndDisallowClasses {
       Assert.fail("When disallow all classes expected a ClassNotFoundException!");
     } catch (final RuntimeException e) {
       if (((!(e.getCause() instanceof ClassNotFoundException)) || (!Objects.equals(e.getCause().getMessage(), "java.io.File")))) {
+        throw e;
+      }
+    }
+  }
+
+  @Test
+  public void test_file_graal() throws ScriptCPUAbuseException, ScriptException {
+    NashornSandbox sandbox = GraalSandboxes.create();
+    final String testClassScript = "var File = Java.type('java.io.File'); File;";
+    sandbox.allow(File.class);
+    sandbox.eval(testClassScript);
+    if (!sandbox.isAllowed(File.class)) {
+      Assert.fail("Expected class File is allowed.");
+    }
+    sandbox = GraalSandboxes.create();
+    sandbox.disallow(File.class);
+    try {
+      Object obj = sandbox.eval(testClassScript);
+      Assert.fail("When disallow the File class expected a PolyglotException!");
+    }
+    catch (final javax.script.ScriptException e) {
+      if (((!(e.getCause() instanceof PolyglotException)) || (!Objects.equals(e.getCause().getMessage(), "TypeError: Access to host class java.io.File is not allowed or does not exist.")))) {
+        throw e;
+      }
+    }
+    sandbox = GraalSandboxes.create();
+    sandbox.allow(File.class);
+    sandbox.disallowAllClasses();
+    try {
+      sandbox.eval(testClassScript);
+      Assert.fail("When disallow all classes expected a PolyglotException!");
+    } catch (final javax.script.ScriptException e) {
+      if (((!(e.getCause() instanceof PolyglotException)) || (!Objects.equals(e.getCause().getMessage(), "TypeError: Access to host class java.io.File is not allowed or does not exist.")))) {
         throw e;
       }
     }

--- a/src/test/java/delight/nashornsandbox/TestBindingsInsert.java
+++ b/src/test/java/delight/nashornsandbox/TestBindingsInsert.java
@@ -17,11 +17,26 @@ public class TestBindingsInsert {
         final NashornSandbox sandbox = NashornSandboxes.create();
         assertNull(sandbox.eval("var $ARG=\"a\"; $ARG;"));
     }
+    
+    @Test
+    @Ignore("This shows that you can override the secure settings")
+    public void testOverride_graal() throws ScriptCPUAbuseException, ScriptException {
+        final NashornSandbox sandbox = GraalSandboxes.create();
+        assertNull(sandbox.eval("var $ARG=\"a\"; $ARG;"));
+    }
 
     @Test
     //This shows that with the override we will restore to the secure settings so the next script that runs through should be fine
     public void testInsertOptions() throws ScriptCPUAbuseException, ScriptException {
         final NashornSandbox sandbox = NashornSandboxes.create();
+        sandbox.eval("var $ARG=\"a\";");
+        assertNull(sandbox.eval("$ARG;"));
+    }
+    
+    @Test
+    //This shows that with the override we will restore to the secure settings so the next script that runs through should be fine
+    public void testInsertOptions_graal() throws ScriptCPUAbuseException, ScriptException {
+        final NashornSandbox sandbox = GraalSandboxes.create();
         sandbox.eval("var $ARG=\"a\";");
         assertNull(sandbox.eval("$ARG;"));
     }
@@ -34,10 +49,28 @@ public class TestBindingsInsert {
         sandbox.eval("$ARG", bindings);
         assertNull(sandbox.eval("$ARG;"));
     }
+    
+    @Test
+    public void testInsertOptionsWithBinding_graal() throws ScriptCPUAbuseException, ScriptException {
+        final NashornSandbox sandbox = GraalSandboxes.create();
+        final Bindings bindings = sandbox.createBindings();
+        bindings.put("$ARG","a");
+        sandbox.eval("$ARG", bindings);
+        assertNull(sandbox.eval("$ARG;"));
+    }
 
     @Test
     public void testInsertOptionsWithBinding2() throws ScriptCPUAbuseException, ScriptException {
         final NashornSandbox sandbox = NashornSandboxes.create();
+        final Bindings bindings = sandbox.createBindings();
+        bindings.put("$ARG","a");
+        sandbox.eval("var $ARG=\"a\";", bindings);
+        assertNull(sandbox.eval("$ARG;"));
+    }
+    
+    @Test
+    public void testInsertOptionsWithBinding2_graal() throws ScriptCPUAbuseException, ScriptException {
+        final NashornSandbox sandbox = GraalSandboxes.create();
         final Bindings bindings = sandbox.createBindings();
         bindings.put("$ARG","a");
         sandbox.eval("var $ARG=\"a\";", bindings);

--- a/src/test/java/delight/nashornsandbox/TestBuiltInObjectsAccess.java
+++ b/src/test/java/delight/nashornsandbox/TestBuiltInObjectsAccess.java
@@ -7,8 +7,7 @@ import org.junit.Test;
 import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 public class TestBuiltInObjectsAccess {
-	
-	
+
 	@Test
 	public void test_block_access() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
@@ -16,6 +15,12 @@ public class TestBuiltInObjectsAccess {
 		sandbox.eval("exit()");
 		sandbox.eval("quit()");
 	}
-	
-	
+
+	@Test
+	public void test_block_access_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		
+		sandbox.eval("exit()");
+		sandbox.eval("quit()");
+	}
 }

--- a/src/test/java/delight/nashornsandbox/TestCustomCache.java
+++ b/src/test/java/delight/nashornsandbox/TestCustomCache.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 public class TestCustomCache {
+	
 	public static class CustomCache implements SecuredJsCache {
 
 		private boolean consulted = false;
@@ -31,6 +32,25 @@ public class TestCustomCache {
 	@Test
 	public void testCustomCacheUsage() throws ScriptCPUAbuseException, ScriptException {
 		NashornSandbox sb = NashornSandboxes.create();
+		final CustomCache cache = new CustomCache();
+		sb.setScriptCache(cache);
+		Object result = sb.eval("5 ;");
+
+		assertTrue(cache.consulted);
+		assertNull(result);
+		assertEquals("5 ;", cache.source);
+
+		// In case this fails because of changes to the beautify-routine:
+		// The actual value is not that important, this is just
+		// a plausibility check to determine whether "producer"
+		// has been passed correctly to the cache's getOrCreate()
+		// method.
+		assertEquals("5;", cache.produced);
+	}
+
+	@Test
+	public void testCustomCacheUsage_graal() throws ScriptCPUAbuseException, ScriptException {
+		NashornSandbox sb = GraalSandboxes.create();
 		final CustomCache cache = new CustomCache();
 		sb.setScriptCache(cache);
 		Object result = sb.eval("5 ;");

--- a/src/test/java/delight/nashornsandbox/TestEngine.java
+++ b/src/test/java/delight/nashornsandbox/TestEngine.java
@@ -9,29 +9,51 @@ import junit.framework.Assert;
 
 public class TestEngine {
 	
-	
 	@Test(expected = ScriptException.class)
 	public void test() throws ScriptCPUAbuseException, ScriptException {
-		
+
 		NashornSandbox sandbox = NashornSandboxes.create();
 		
 		Assert.assertEquals(null, sandbox.eval("this.engine.factory"));
 		
 	}
 	
+	@Test(expected = ScriptException.class)
+	public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+
+		NashornSandbox sandbox = GraalSandboxes.create();
+		NashornSandbox sandbox2 = GraalSandboxes.create();
+
+		Assert.assertEquals(null, sandbox.eval("this.engine.factory"));
+
+	}
 	
+
 	@Test(expected = ScriptException.class)
 	public void test_with_delete() throws ScriptCPUAbuseException, ScriptException {
 		
 		NashornSandbox sandbox = NashornSandboxes.create();
-		 sandbox.eval("Object.defineProperty(this, 'engine', {});\n" + 
-         		"Object.defineProperty(this, 'context', {});");
-         sandbox.eval("delete this.__noSuchProperty__;");
+
+		sandbox.eval("Object.defineProperty(this, 'engine', {});\n" + "Object.defineProperty(this, 'context', {});");
+        sandbox.eval("delete this.__noSuchProperty__;");
 		sandbox.eval("delete this.engine; this.engine.factory;");
 		sandbox.eval("delete this.engine; this.engine.factory.scriptEngine.compile('var File = Java.type(\"java.io.File\"); File;').eval()");
-		
+
 		Assert.assertEquals(null, sandbox.eval("delete this.engine; this.engine.factory;"));
-		
+
 	}
-	
+
+	@Test(expected = ScriptException.class)
+	public void test_with_delete_graal() throws ScriptCPUAbuseException, ScriptException {
+
+		NashornSandbox sandbox = GraalSandboxes.create();
+
+		sandbox.eval("Object.defineProperty(this, 'engine', {});\n" +  "Object.defineProperty(this, 'context', {});");
+        sandbox.eval("delete this.__noSuchProperty__;");
+		sandbox.eval("delete this.engine; this.engine.factory;");
+		sandbox.eval("delete this.engine; this.engine.factory.scriptEngine.compile('var File = Java.type(\"java.io.File\"); File;').eval()");
+
+		Assert.assertEquals(null, sandbox.eval("delete this.engine; this.engine.factory;"));
+
+	}
 }

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptBindings.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptBindings.java
@@ -30,6 +30,24 @@ public class TestEvalWithScriptBindings {
   }
   
   @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    
+    Bindings binding1 = sandbox.createBindings();
+    binding1.put("y", 2);
+    
+    final Object res1 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", binding1);
+    Assert.assertEquals(3, res1);
+
+    Bindings binding2 = sandbox.createBindings();
+    binding2.put("y", 4);
+    
+    final Object res2 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", binding2);
+    Assert.assertEquals(5, res2);
+    
+  }
+  
+  @Test
   public void testWithCPUAndMemory() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
     sandbox.setMaxCPUTime(100);
@@ -46,6 +64,26 @@ public class TestEvalWithScriptBindings {
 
     final Object res2 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", binding2);
     Assert.assertEquals(5.0, res2);
+    
+  }
+  
+  @Test
+  public void testWithCPUAndMemory_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.setMaxCPUTime(100);
+    sandbox.setMaxMemory(1000 * 1024);
+    sandbox.setExecutor(Executors.newSingleThreadExecutor());
+    Bindings binding1 = sandbox.createBindings();
+    binding1.put("y", 2);
+    
+    final Object res1 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", binding1);
+    Assert.assertEquals(3, res1);
+
+    Bindings binding2 = sandbox.createBindings();
+    binding2.put("y", 4);
+
+    final Object res2 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", binding2);
+    Assert.assertEquals(5, res2);
     
   }
 }

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContext.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContext.java
@@ -34,6 +34,25 @@ public class TestEvalWithScriptContext {
   }
   
   @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    ScriptContext newContext1 = new SimpleScriptContext();
+    Bindings engineScope1 = newContext1.getBindings(ScriptContext.ENGINE_SCOPE);
+    engineScope1.put("y", 2);
+    
+    ScriptContext newContext2 = new SimpleScriptContext();
+    Bindings engineScope2 = newContext2.getBindings(ScriptContext.ENGINE_SCOPE);
+    engineScope2.put("y", 4);
+    
+    final Object res1 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext1);
+    Assert.assertEquals(3, res1);
+    
+    final Object res2 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext2);
+    Assert.assertEquals(5, res2);
+    
+  }
+  
+  @Test
   public void testWithCPUAndMemory() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
     sandbox.setMaxCPUTime(100);
@@ -52,6 +71,28 @@ public class TestEvalWithScriptContext {
     
     final Object res2 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext2);
     Assert.assertEquals(5.0, res2);
+    
+  }
+  
+  @Test
+  public void testWithCPUAndMemory_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.setMaxCPUTime(100);
+    sandbox.setMaxMemory(1000 * 1024);
+    sandbox.setExecutor(Executors.newSingleThreadExecutor());
+    ScriptContext newContext1 = new SimpleScriptContext();
+    Bindings engineScope1 = newContext1.getBindings(ScriptContext.ENGINE_SCOPE);
+    engineScope1.put("y", 2);
+    
+    ScriptContext newContext2 = new SimpleScriptContext();
+    Bindings engineScope2 = newContext2.getBindings(ScriptContext.ENGINE_SCOPE);
+    engineScope2.put("y", 4);
+    
+    final Object res1 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext1);
+    Assert.assertEquals(3, res1);
+    
+    final Object res2 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext2);
+    Assert.assertEquals(5, res2);
     
   }
 }

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithNewBindings.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithNewBindings.java
@@ -18,10 +18,33 @@ public class TestEvalWithScriptContextWithNewBindings {
 		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newBinding);
 		Assert.assertEquals(2112018.0, res);
 	}
+	
+	@Test
+	public void testWithNewBindings_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		// Create new binding to override the ECMAScript Global properties
+		Bindings newBinding = sandbox.createBindings();
+		Object obj = newBinding.get("Date");
+		newBinding.put("Date", "2112018");
+
+		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newBinding);
+		Assert.assertEquals(2112018, res);
+	}
 
 	@Test
 	public void testWithNewSimpleBindings() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		// Create new binding to override the ECMAScript Global properties
+		Bindings newBinding = new SimpleBindings();
+		newBinding.put("Date", "2112018");
+
+		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newBinding);
+		Assert.assertTrue(Double.isNaN((Double)res));
+	}
+	
+	@Test
+	public void testWithNewSimpleBindings_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
 		// Create new binding to override the ECMAScript Global properties
 		Bindings newBinding = new SimpleBindings();
 		newBinding.put("Date", "2112018");
@@ -42,10 +65,36 @@ public class TestEvalWithScriptContextWithNewBindings {
 		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newContext);
 		Assert.assertEquals(2112018.0, res);
 	}
+	
+	@Test
+	public void testWithNewBindingsScriptContext_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		ScriptContext newContext = new SimpleScriptContext();
+		// Create new binding to override the ECMAScript Global properties 
+		Bindings newBinding = sandbox.createBindings();
+		newBinding.put("Date", "2112018");
+		newContext.setBindings(newBinding, ScriptContext.ENGINE_SCOPE);
+
+		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newContext);
+		Assert.assertEquals(2112018, res);
+	}
 
 	@Test
 	public void testWithExistingBindings() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		ScriptContext newContext = new SimpleScriptContext();
+		Bindings newBinding = newContext.getBindings(ScriptContext.ENGINE_SCOPE);
+		// This will not be updated by using existing bindings, since Date is a 
+		// ECMAScript "global" properties and it is being in ENGINE_SCOPE
+		newBinding.put("Date", "2112018");
+
+		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newContext);
+		Assert.assertTrue(Double.isNaN((Double)res));
+	}
+	
+	@Test
+	public void testWithExistingBindings_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
 		ScriptContext newContext = new SimpleScriptContext();
 		Bindings newBinding = newContext.getBindings(ScriptContext.ENGINE_SCOPE);
 		// This will not be updated by using existing bindings, since Date is a 

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithVariables.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithVariables.java
@@ -32,8 +32,45 @@ public class TestEvalWithScriptContextWithVariables {
   }
   
   @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    ScriptContext newContext1 = new SimpleScriptContext();
+    ScriptContext newContext2 = new SimpleScriptContext();
+    
+    sandbox.eval("function cal() {var x = 1; return x;}", newContext1);
+    sandbox.eval("function cal() {var x = 2; return x;}", newContext2);
+    
+    final Object res1 = sandbox.eval("cal();", newContext1);
+    Assert.assertEquals(1, res1);
+    
+    final Object res2 = sandbox.eval("cal();", newContext2);
+    Assert.assertEquals(2, res2);
+    
+  }
+  
+  @Test
   public void testWithCPUAndMemory() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
+    sandbox.setMaxCPUTime(100);
+    sandbox.setMaxMemory(1000 * 1024);
+    sandbox.setExecutor(Executors.newSingleThreadExecutor());
+    ScriptContext newContext1 = new SimpleScriptContext();
+    ScriptContext newContext2 = new SimpleScriptContext();
+    
+    sandbox.eval("function cal() {var x = 1; return x;}", newContext1);
+    sandbox.eval("function cal() {var x = 2; return x;}", newContext2);
+    
+    final Object res1 = sandbox.eval("cal();", newContext1);
+    Assert.assertEquals(1, res1);
+    
+    final Object res2 = sandbox.eval("cal();", newContext2);
+    Assert.assertEquals(2, res2);
+    
+  }
+  
+  @Test
+  public void testWithCPUAndMemory_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
     sandbox.setMaxCPUTime(100);
     sandbox.setMaxMemory(1000 * 1024);
     sandbox.setExecutor(Executors.newSingleThreadExecutor());

--- a/src/test/java/delight/nashornsandbox/TestExceptions.java
+++ b/src/test/java/delight/nashornsandbox/TestExceptions.java
@@ -17,6 +17,12 @@ public class TestExceptions {
     sandbox.eval("blah_blah_blah();");
   }
   
+  @Test(expected = Exception.class)
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.eval("blah_blah_blah();");
+  }
+  
   @Test
   public void test_with_catch() {
     try {
@@ -34,9 +40,43 @@ public class TestExceptions {
   }
   
   @Test
+  public void test_with_catch_graal() {
+    try {
+      final NashornSandbox sandbox = GraalSandboxes.create();
+      sandbox.eval("blah_blah_blah();");
+    } catch (final Throwable _t) {
+      if (_t instanceof Throwable) {
+        final Throwable t = _t;
+        return;
+      } else {
+        throw new RuntimeException(_t);
+      }
+    }
+    Assert.fail("Exception not thrown!");
+  }
+  
+  @Test
   public void test_with_thread() {
     try {
       final NashornSandbox sandbox = NashornSandboxes.create();
+      sandbox.setMaxCPUTime(100);
+      sandbox.setExecutor(Executors.newSingleThreadExecutor());
+      sandbox.eval("blah_blah_blah();");
+    } catch (final Throwable _t) {
+      if (_t instanceof Throwable) {
+        final Throwable t = _t;
+        return;
+      } else {
+        throw new RuntimeException(_t);
+      }
+    }
+    Assert.fail("Exception not thrown!");
+  }
+  
+  @Test
+  public void test_with_thread_graal() {
+    try {
+      final NashornSandbox sandbox = GraalSandboxes.create();
       sandbox.setMaxCPUTime(100);
       sandbox.setExecutor(Executors.newSingleThreadExecutor());
       sandbox.eval("blah_blah_blah();");
@@ -72,6 +112,36 @@ public class TestExceptions {
         final Throwable t = _t;
         sandbox.getExecutor().shutdown();
         Assert.assertTrue(t.getMessage().contains("4"));
+        return;
+      } else {
+        throw new RuntimeException(_t);
+      }
+    }
+    Assert.fail("Exception not thrown!");
+  }
+  
+  @Test
+  public void test_with_line_number_graal() {
+    NashornSandbox sandbox = null;
+    try {
+      sandbox = GraalSandboxes.create();
+      sandbox.setMaxCPUTime(5000);
+      sandbox.setExecutor(Executors.newSingleThreadExecutor());
+      final StringBuilder _builder = new StringBuilder();
+      _builder.append("var in_the_first_line_all_good;\n");
+      _builder.append("\t\t\t");
+      _builder.append("var so_is_the_second;\n");
+      _builder.append("\t\t\t");
+      _builder.append("var and_the_third;\n");
+      _builder.append("\t\t\t");
+      _builder.append("blah_blah_blah();");
+      sandbox.eval(_builder.toString());
+    } catch (final Throwable _t) {
+      if (_t instanceof Throwable) {
+        final Throwable t = _t;
+        sandbox.getExecutor().shutdown();
+        // no line numbers reported for graal
+        Assert.assertTrue(t.getMessage().contains("blah_blah_blah is not defined"));
         return;
       } else {
         throw new RuntimeException(_t);

--- a/src/test/java/delight/nashornsandbox/TestExit.java
+++ b/src/test/java/delight/nashornsandbox/TestExit.java
@@ -14,10 +14,22 @@ public class TestExit {
     final NashornSandbox sandbox = NashornSandboxes.create();
     sandbox.eval("exit();");
   }
+  
+  @Test
+  public void testExit_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.eval("exit();");
+  }
 
   @Test
   public void testQuit() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
+    sandbox.eval("quit();");
+  }
+  
+  @Test
+  public void testQuit_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
     sandbox.eval("quit();");
   }
 
@@ -26,11 +38,24 @@ public class TestExit {
     final NashornSandbox sandbox = NashornSandboxes.create();
     sandbox.eval("quit();", sandbox.createBindings());
   }
+  
+  @Test
+  public void testQuitWithBindings_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.eval("quit();", sandbox.createBindings());
+  }
 
   @Test
   @Ignore("This will fail as there is no confirmation on Script Contexts")
   public void testQuitWithScriptContext() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
+    sandbox.eval("quit();", new SimpleScriptContext());
+  }
+  
+  @Test
+  @Ignore("This will fail as there is no confirmation on Script Contexts")
+  public void testQuitWithScriptContext_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
     sandbox.eval("quit();", new SimpleScriptContext());
   }
 }

--- a/src/test/java/delight/nashornsandbox/TestGetFunction.java
+++ b/src/test/java/delight/nashornsandbox/TestGetFunction.java
@@ -31,4 +31,23 @@ public class TestGetFunction {
 		executor.shutdown();
 	}
 	
+	@Test
+	public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+		NashornSandbox sandbox = GraalSandboxes.create();
+		sandbox.setMaxCPUTime(100);
+		sandbox.setMaxMemory(1000 * 1024); // GraalVM needs more memory
+		sandbox.allowNoBraces(false);
+		sandbox.setMaxPreparedStatements(30); // because preparing scripts for
+		// execution is expensive
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		sandbox.setExecutor(executor);
+		
+		sandbox.eval("function callMe() { return 42; };");
+		final Object _get = sandbox.get("callMe");
+		
+		Assert.assertTrue(_get != null);
+		
+		executor.shutdown();
+	}
+	
 }

--- a/src/test/java/delight/nashornsandbox/TestGlobalVariable.java
+++ b/src/test/java/delight/nashornsandbox/TestGlobalVariable.java
@@ -19,4 +19,14 @@ public class TestGlobalVariable {
     sandbox.allow(Class.class);
     sandbox.eval("fromJava.toString();");
   }
+  
+  @Test
+  public void test_java_variable_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    final Object _object = new Object();
+    sandbox.inject("fromJava", _object);
+    sandbox.allow(String.class);
+    sandbox.allow(Class.class);
+    sandbox.eval("fromJava.toString();");
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestIfElse.java
+++ b/src/test/java/delight/nashornsandbox/TestIfElse.java
@@ -40,4 +40,32 @@ public class TestIfElse {
     Assert.assertEquals(Integer.valueOf(4), sandbox.eval("y"));
     sandbox.getExecutor().shutdown();
   }
+  
+  @Test
+  public void testIfElse_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.setMaxCPUTime(500);
+    sandbox.setExecutor(Executors.newSingleThreadExecutor());
+    final StringBuilder _builder = new StringBuilder();
+    _builder.append("if (true)\n");
+    _builder.append("var x=1;\n");
+    _builder.append("else\n");
+    _builder.append("var y=2;\t\t\n");
+    sandbox.eval(_builder.toString());
+    Assert.assertEquals(Integer.valueOf(1), sandbox.eval("x"));
+    final StringBuilder _builder_1 = new StringBuilder();
+    _builder_1.append("for (var i=0;i<10;i++) {\n");
+    _builder_1.append("    ");
+    _builder_1.append("if (false)\n");
+    _builder_1.append("    \t");
+    _builder_1.append("var x=3;\n");
+    _builder_1.append("    ");
+    _builder_1.append("else\n");
+    _builder_1.append("    \t");
+    _builder_1.append("var y=4;\t\n");
+    _builder_1.append("}\n");
+    sandbox.eval(_builder_1.toString());
+    Assert.assertEquals(Integer.valueOf(4), sandbox.eval("y"));
+    sandbox.getExecutor().shutdown();
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestInaccessible.java
+++ b/src/test/java/delight/nashornsandbox/TestInaccessible.java
@@ -17,8 +17,20 @@ public class TestInaccessible {
   }
   
   @Test(expected = Exception.class)
+  public void test_system_exit_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.eval("java.lang.System.exit(0);");
+  }
+  
+  @Test(expected = Exception.class)
   public void test_file() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
+    sandbox.eval("var File = Java.type(\"java.io.File\"); File;");
+  }
+  
+  @Test(expected = Exception.class)
+  public void test_file_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
     sandbox.eval("var File = Java.type(\"java.io.File\"); File;");
   }
 }

--- a/src/test/java/delight/nashornsandbox/TestInvocable.java
+++ b/src/test/java/delight/nashornsandbox/TestInvocable.java
@@ -19,6 +19,15 @@ public class TestInvocable {
 		Invocable invocable = sandbox.getSandboxedInvocable();
 		assertEquals(1, invocable.invokeFunction("x"));
 	}
+	
+	@Test
+	public void testInvokeFunction_graal() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		final String script = "function x(){return 1;}\n";
+		sandbox.eval(script);
+		Invocable invocable = sandbox.getSandboxedInvocable();
+		assertEquals(1, invocable.invokeFunction("x"));
+	}
 
 	@Test
 	public void testInvokeMethod() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
@@ -29,6 +38,17 @@ public class TestInvocable {
 		Invocable invocable = sandbox.getSandboxedInvocable();
 
 		assertEquals(3.0, invocable.invokeMethod(thisobj, "x", 2));
+	}
+	
+	@Test
+	public void testInvokeMethod_graal() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		final String script = "var obj = {n: 1, x:function(arg){return this.n + arg;}};";
+		sandbox.eval(script);
+		Object thisobj = sandbox.get("obj");
+		Invocable invocable = sandbox.getSandboxedInvocable();
+
+		assertEquals(3, invocable.invokeMethod(thisobj, "x", 2));
 	}
 
 }

--- a/src/test/java/delight/nashornsandbox/TestIssue34.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue34.java
@@ -18,7 +18,9 @@ import junit.framework.Assert;
 public class TestIssue34 {
 
 	Logger logger;
+	Logger loggerGraal;
 	NashornSandbox sandbox;
+	NashornSandbox sandboxGraal;
 
 	public static class Logger {
 
@@ -44,6 +46,16 @@ public class TestIssue34 {
 		sandbox.setExecutor(Executors.newSingleThreadExecutor());
 		logger = new Logger();
 		sandbox.inject("logger", logger);
+		
+		sandboxGraal = GraalSandboxes.create();
+		sandboxGraal.setMaxCPUTime(100); // in millis
+		sandboxGraal.setMaxMemory(1000 * 1000 * 100); // 100 MB for GraalVM
+		sandboxGraal.allowNoBraces(false);
+		sandboxGraal.allowPrintFunctions(true);
+		sandboxGraal.setMaxPreparedStatements(30);
+		sandboxGraal.setExecutor(Executors.newSingleThreadExecutor());
+		loggerGraal = new Logger();
+		sandboxGraal.inject("logger", loggerGraal);
 	}
 
 	@Test
@@ -60,6 +72,23 @@ public class TestIssue34 {
 		sandbox.eval(js);
 
 		Assert.assertTrue(logger.getOutput().contains("loop cnt-0"));
+
+	}
+	
+	@Test
+	public void testIssue34_Scenario1_graal() throws ScriptCPUAbuseException, ScriptException {
+		String js = "";
+		js += "function main(){\n";
+		js += "	for(var i=0;i<2;i++)\n";
+		js += "	logger.debug('loop cnt-'+i);\n";
+		js += "}\n";
+		js += "function main2(){\n";
+		js += "}\n";
+		js += "main();\n";
+
+		sandboxGraal.eval(js);
+
+		Assert.assertTrue(loggerGraal.getOutput().contains("loop cnt-0"));
 
 	}
 
@@ -81,6 +110,25 @@ public class TestIssue34 {
 		Assert.assertTrue(ex instanceof BracesException);
 
 	}
+	
+	@Test
+	public void testIssue34_Scenario2_graal() throws ScriptCPUAbuseException, ScriptException {
+		String js = "";
+		js += "function main(){\n" + "logger.debug(\"... In fun1()....\");\n" + "for(var i=0;i<2;i++)//{\n"
+				+ "logger.debug(\"loop cnt-\"+i);\n" + "}\n" + "main();";
+		
+		
+		
+		Throwable ex = null;
+		try {
+			sandboxGraal.eval(js);
+		} catch (Throwable t) {
+			ex = t;
+		}
+
+		Assert.assertTrue(ex instanceof BracesException);
+
+	}
 
 	@Test
 	public void testIssue34_Scenario3() throws ScriptCPUAbuseException, ScriptException {
@@ -91,6 +139,18 @@ public class TestIssue34 {
 		sandbox.eval(js);
 
 		Assert.assertTrue(logger.getOutput().contains("loop cnt=6"));
+
+	}
+	
+	@Test
+	public void testIssue34_Scenario3_graal() throws ScriptCPUAbuseException, ScriptException {
+		String js = "";
+		js += "function loopTest(){\n" + "var i=0;\n" + "do{\n" + "logger.debug(\"loop cnt=\"+(++i));\n"
+				+ "}while(i<11)\n" + "}\n" + "loopTest();";
+
+		sandboxGraal.eval(js);
+
+		Assert.assertTrue(loggerGraal.getOutput().contains("loop cnt=6"));
 
 	}
 	
@@ -112,6 +172,23 @@ public class TestIssue34 {
 	}
 	
 	@Test
+	public void testIssue34_Scenario3_2_graal() throws ScriptCPUAbuseException, ScriptException {
+    String js = "//simple do-while loop for demo\n";
+		js += "function loopTest(){\n" +
+    "var i=0;\n" +
+				"do{\n" +
+    "logger.debug(\"loop cnt=\"+(++i));\n"
+				+ "}while(i<11);" + "}\n" +
+    "loopTest();";
+
+		
+		sandboxGraal.eval(js);
+
+		Assert.assertTrue(loggerGraal.getOutput().contains("loop cnt=6"));
+
+	}
+	
+	@Test
 	public void testIssue34_Scenario4()  {
 		String js = "";
 		js += "if(srctable.length) srctable.length = 0;__if();\n" + "else {\n" + "for(var key in srctable) {__if();\n"
@@ -120,6 +197,23 @@ public class TestIssue34 {
 		Throwable ex = null;
 		try {
 			sandbox.eval(js);
+		} catch (Throwable t) {
+			ex = t;
+		}
+
+		Assert.assertTrue(ex instanceof IllegalArgumentException);
+
+	}
+	
+	@Test
+	public void testIssue34_Scenario4_graal()  {
+		String js = "";
+		js += "if(srctable.length) srctable.length = 0;__if();\n" + "else {\n" + "for(var key in srctable) {__if();\n"
+				+ "delete srctable[key];\n" + "}\n" + "}";
+
+		Throwable ex = null;
+		try {
+			sandboxGraal.eval(js);
 		} catch (Throwable t) {
 			ex = t;
 		}
@@ -149,10 +243,33 @@ public class TestIssue34 {
 		Assert.assertTrue(ex instanceof ScriptCPUAbuseException);
 
 	}
+	
+	@Test
+	public void testIssue34_Scenario5_graal() {
+		String js = "";
+		js += "function loopTest(){\n" + 
+				"var i=0;\n" + 
+				"do{\n" + 
+				"i++;\n" + 
+				"}while(true)\n" + 
+				"}\n" + 
+				"loopTest();";
+
+		Throwable ex = null;
+		try {
+			sandboxGraal.eval(js);
+		} catch (Throwable t) {
+			ex = t;
+		}
+		
+		Assert.assertTrue(ex instanceof ScriptCPUAbuseException);
+
+	}
 
 	@After
 	public void tearDown() {
 		sandbox.getExecutor().shutdown();
+		sandboxGraal.getExecutor().shutdown();
 	}
 
 }

--- a/src/test/java/delight/nashornsandbox/TestIssue36.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue36.java
@@ -27,4 +27,19 @@ public class TestIssue36 {
 	        
 	}
 	
+	@Test
+	public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+		 NashornSandbox sandbox = GraalSandboxes.create();
+	        sandbox.setMaxCPUTime(100);
+	        sandbox.setMaxMemory(1000 * 1000);
+	        sandbox.allowNoBraces(false);
+	        ExecutorService executor = Executors.newSingleThreadExecutor();
+	        sandbox.setExecutor(executor);
+	        Boolean done = (Boolean) sandbox.eval("done = false;");
+	        Assert.assertFalse(done);
+	        
+	        sandbox.getExecutor().shutdown();
+	        
+	}
+	
 }

--- a/src/test/java/delight/nashornsandbox/TestIssue40_ScriptEngineParameters.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue40_ScriptEngineParameters.java
@@ -27,4 +27,14 @@ public class TestIssue40_ScriptEngineParameters {
 		
 	}
 	
+	@Test(expected=ScriptException.class)
+	public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+
+		final NashornSandbox sandbox = GraalSandboxes.create("-strict");
+	    sandbox.allow(File.class);
+
+	    // should throw an exception since 'Java' is not allowed.
+	    sandbox.eval("idontexist = 1;");
+	}
+
 }

--- a/src/test/java/delight/nashornsandbox/TestIssue47.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue47.java
@@ -29,6 +29,24 @@ public class TestIssue47 {
 		sandbox.getExecutor().shutdown();
 
 	}
+	
+	@Test
+	public void test_valid_graal() throws ScriptCPUAbuseException, ScriptException {
+
+		String js = "function preProcessor()\n" + "{\n" + "var map =  { \"inputparam\": \" for \" };\n" + "}\n"
+				+ "preProcessor();";
+
+		NashornSandbox sandbox = GraalSandboxes.create();
+		sandbox.setMaxCPUTime(100);
+		sandbox.setMaxMemory(1000 * 1000 * 100); // GraalVM needs more
+		sandbox.allowNoBraces(false);
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		sandbox.setExecutor(executor);
+		sandbox.eval(js);
+
+		sandbox.getExecutor().shutdown();
+
+	}
 
 	@Test(expected=BracesException.class)
 	public void test_invalid() throws ScriptCPUAbuseException, ScriptException {
@@ -38,6 +56,26 @@ public class TestIssue47 {
 					+ "}\n" + "preProcessor();";
 
 			sandbox = NashornSandboxes.create();
+			sandbox.setMaxCPUTime(100);
+			sandbox.setMaxMemory(1000 * 1000);
+			sandbox.allowNoBraces(false);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			sandbox.setExecutor(executor);
+			sandbox.eval(js);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+
+	}
+	
+	@Test(expected=BracesException.class)
+	public void test_invalid_graal() throws ScriptCPUAbuseException, ScriptException {
+		NashornSandbox sandbox = null;
+		try {
+			String js = "function preProcessor()\n" + "{\n" + "var map =  { \"inputparam\": \"l\" }; for (;;); \n"
+					+ "}\n" + "preProcessor();";
+
+			sandbox = GraalSandboxes.create();
 			sandbox.setMaxCPUTime(100);
 			sandbox.setMaxMemory(1000 * 1000);
 			sandbox.allowNoBraces(false);

--- a/src/test/java/delight/nashornsandbox/TestIssue54.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue54.java
@@ -9,7 +9,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
-import delight.nashornsandbox.internal.InterruptTest;
 
 public class TestIssue54 {
 
@@ -30,7 +29,30 @@ public class TestIssue54 {
 		    sandbox.eval(js);
 		    sandbox.getExecutor().shutdown();
 		} catch (final Exception e) {
-		    Assert.assertEquals(e.getClass(), ScriptCPUAbuseException.class);
+		    Assert.assertEquals(ScriptCPUAbuseException.class, e.getClass());
+		}
+
+
+	}
+	
+	@Test
+	public void test_valid_graal() throws ScriptCPUAbuseException, ScriptException {
+
+		String js = "var x = 1;\nwhile (true) { }\n";
+
+		NashornSandbox sandbox = GraalSandboxes.create();
+		sandbox.setMaxCPUTime(100);
+		sandbox.setMaxMemory(1000 * 1000 * 100); // GraalVM needs more
+		sandbox.allowNoBraces(false);
+		sandbox.disallowAllClasses();
+
+		try {
+		    ExecutorService executor = Executors.newSingleThreadExecutor();
+		    sandbox.setExecutor(executor);
+		    sandbox.eval(js);
+		    sandbox.getExecutor().shutdown();
+		} catch (final Exception e) {
+		    Assert.assertEquals(ScriptCPUAbuseException.class, e.getClass());
 		}
 
 

--- a/src/test/java/delight/nashornsandbox/TestIssue57.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue57.java
@@ -25,5 +25,17 @@ public class TestIssue57 {
 		Double sandboxResults = (Double) NashornSandboxes.create(NASHORN_ARGS).eval(script);
 		assertEquals(14, sandboxResults.intValue());
 	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testMapReduce_graal() throws ScriptException {
+		String script = "[1,2,3,4].map(function(n){return n+1}).reduce(function(prev,cur){return prev+cur}, 0)";
+		String[] NASHORN_ARGS = {"--no-java", "--no-syntax-extensions" };
+		
+		Double nashornResult = (Double) new NashornScriptEngineFactory().getScriptEngine(NASHORN_ARGS).eval(script);
+		assertEquals(14, nashornResult.intValue());
+		
+		Double sandboxResults = (Double) GraalSandboxes.create(NASHORN_ARGS).eval(script);
+		assertEquals(14, sandboxResults.intValue());
+	}
 
 }

--- a/src/test/java/delight/nashornsandbox/TestKeepVariables.java
+++ b/src/test/java/delight/nashornsandbox/TestKeepVariables.java
@@ -19,4 +19,13 @@ public class TestKeepVariables {
     final Object res = sandbox.eval("window.val1;");
     Assert.assertEquals("myval", res);
   }
+  
+  @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.eval("var window={};");
+    sandbox.eval("window.val1 = \"myval\";");
+    final Object res = sandbox.eval("window.val1;");
+    Assert.assertEquals("myval", res);
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestLimitCPU.java
+++ b/src/test/java/delight/nashornsandbox/TestLimitCPU.java
@@ -34,10 +34,50 @@ public class TestLimitCPU {
 			sandbox.getExecutor().shutdown();
 		}
 	}
+	
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		try {
+			sandbox.setMaxCPUTime(50);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			final StringBuilder _builder = new StringBuilder();
+			_builder.append("var x = 1;\n");
+			_builder.append("while (true) {\n");
+			_builder.append("\t");
+			_builder.append("x=x+1;\n");
+			_builder.append("}\n");
+			sandbox.eval(_builder.toString());
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_evil_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		sandbox.setMaxCPUTime(50);
+		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		final String js = "var x = 1;\nwhile (true) { }\n";
+		try {
+			// try evaluate bad js
+			try {
+				sandbox.eval(js);
+				fail("Should exception be thrown");
+			} catch (final BracesException e) {
+				// nothing to do
+			}
+			// allow evaluate bad js
+			sandbox.allowNoBraces(true);
+			sandbox.eval(js);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
+	
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_evil_script_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
 		sandbox.setMaxCPUTime(50);
 		sandbox.setExecutor(Executors.newSingleThreadExecutor());
 		final String js = "var x = 1;\nwhile (true) { }\n";
@@ -71,6 +111,21 @@ public class TestLimitCPU {
 		sandbox.eval(_builder.toString());
 		sandbox.getExecutor().shutdown();
 	}
+	
+	@Test
+	public void test_nice_script_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		sandbox.setMaxCPUTime(500);
+		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		final StringBuilder _builder = new StringBuilder();
+		_builder.append("var x = 1;\n");
+		_builder.append("for (var i=0;i<=1000;i++) {\n");
+		_builder.append("\t");
+		_builder.append("x = x + i\n");
+		_builder.append("}\n");
+		sandbox.eval(_builder.toString());
+		sandbox.getExecutor().shutdown();
+	}
 
 	@Test(expected = BracesException.class)
 	public void test_only_while() throws ScriptCPUAbuseException, ScriptException {
@@ -84,10 +139,38 @@ public class TestLimitCPU {
 			sandbox.getExecutor().shutdown();
 		}
 	}
+	
+	@Test(expected = BracesException.class)
+	public void test_only_while_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		sandbox.setMaxCPUTime(50);
+		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		try {
+			final String badScript = "while (true);\n";
+			sandbox.eval(badScript);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_only_while_allowed_bad_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		sandbox.setMaxCPUTime(50);
+		
+		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		try {
+			final String badScript = "while (true);\n";
+			sandbox.allowNoBraces(true);
+			sandbox.eval(badScript);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
+	
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_only_while_allowed_bad_script_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
 		sandbox.setMaxCPUTime(50);
 		
 		sandbox.setExecutor(Executors.newSingleThreadExecutor());
@@ -113,10 +196,37 @@ public class TestLimitCPU {
 			sandbox.getExecutor().shutdown();
 		}
 	}
+	
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_only_while_good_script_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		sandbox.setMaxCPUTime(50);
+		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		try {
+			final String goodScript = "while (true); {i=1;}";
+			sandbox.allowNoBraces(true);
+			sandbox.eval(goodScript);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
 
 	@Test(expected = BracesException.class)
 	public void test_while_plus_iteration_bad_script() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		try {
+			sandbox.setMaxCPUTime(50);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			final String badScirpt = "var x=0;\nwhile (true) x++;\n";
+			sandbox.eval(badScirpt);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
+	
+	@Test(expected = BracesException.class)
+	public void test_while_plus_iteration_bad_scrip_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
 		try {
 			sandbox.setMaxCPUTime(50);
 			sandbox.setExecutor(Executors.newSingleThreadExecutor());
@@ -140,6 +250,20 @@ public class TestLimitCPU {
 			sandbox.getExecutor().shutdown();
 		}
 	}
+	
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_while_plus_iteration_bad_scrip_allowed_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		try {
+			sandbox.setMaxCPUTime(50);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			final String badScirpt = "var x=0;\nwhile (true) x++;\n";
+			sandbox.allowNoBraces(true);
+			sandbox.eval(badScirpt);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_while_plus_iteration() throws ScriptCPUAbuseException, ScriptException {
@@ -153,10 +277,39 @@ public class TestLimitCPU {
 			sandbox.getExecutor().shutdown();
 		}
 	}
+	
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_while_plus_iteration_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
+		try {
+			sandbox.setMaxCPUTime(50);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			final String goodScript = "var x=0;\nwhile (true) {x++;}\n";
+			sandbox.eval(goodScript);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
 
 	@Test(expected = ScriptCPUAbuseException.class)
 	public void test_do_while() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		try {
+			sandbox.setMaxCPUTime(50);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			final StringBuilder _builder = new StringBuilder();
+			_builder.append("do {\n");
+			_builder.append("\t\n");
+			_builder.append("} while (true);\n");
+			sandbox.eval(_builder.toString());
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
+	
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_do_while_graal() throws ScriptCPUAbuseException, ScriptException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
 		try {
 			sandbox.setMaxCPUTime(50);
 			sandbox.setExecutor(Executors.newSingleThreadExecutor());
@@ -198,10 +351,59 @@ public class TestLimitCPU {
 			Assert.assertNotNull(exp);
 		}
 	}
+	
+	@Test
+	public void testIsMatchCpuAbuseDirect_graal() {
+		String js = "while (true) {};";
+		for (int i = 0; i < 20; i++) {
+
+			NashornSandbox sandbox = GraalSandboxes.create();
+			sandbox.setMaxCPUTime(100); // in millis
+			sandbox.setMaxMemory(1000 * 1000); // 1 MB
+			sandbox.allowNoBraces(false);
+			sandbox.setMaxPreparedStatements(30);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			Exception exp = null;
+			try {
+
+				Object result = sandbox.eval(js);
+
+			} catch (Exception e) {
+
+				exp = e;
+			}
+			sandbox.getExecutor().shutdown();
+			Assert.assertNotNull(exp);
+		}
+	}
 
 	@Test
 	public void testCpuLmitInInvocable() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
+		sandbox.setMaxCPUTime(50);
+		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		try {
+			final String badScript = "function x(){while (true){};}\n";
+			try {
+				sandbox.eval(badScript);
+			} catch (ScriptCPUAbuseException e) {
+				fail("we want to test invokeFunction(), but we failed too early");
+			}
+			Invocable invocable = sandbox.getSandboxedInvocable();
+			try {
+				invocable.invokeFunction("x");
+				fail("expected an exception for the infinite loop");
+			} catch (ScriptException e) {
+				assertEquals(ScriptCPUAbuseException.class, e.getCause().getClass());
+			}
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
+	
+	@Test
+	public void testCpuLmitInInvocable_graal() throws ScriptCPUAbuseException, ScriptException, NoSuchMethodException {
+		final NashornSandbox sandbox = GraalSandboxes.create();
 		sandbox.setMaxCPUTime(50);
 		sandbox.setExecutor(Executors.newSingleThreadExecutor());
 		try {

--- a/src/test/java/delight/nashornsandbox/TestManyEvalsAndInjections.java
+++ b/src/test/java/delight/nashornsandbox/TestManyEvalsAndInjections.java
@@ -33,4 +33,25 @@ public class TestManyEvalsAndInjections {
     sandboxInterruption.eval("res = num + str;");
     Assert.assertEquals("1020", sandboxInterruption.get("res"));
   }
+  
+  @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.inject("num", Integer.valueOf(10));
+    sandbox.eval("res = num + 1;");
+    Assert.assertEquals(Integer.valueOf(11), sandbox.get("res"));
+    sandbox.inject("str", "20");
+    sandbox.eval("res = num + str;");
+    Assert.assertEquals("1020", sandbox.get("res"));
+    final NashornSandbox sandboxInterruption = NashornSandboxes.create();
+    sandboxInterruption.setMaxCPUTime(50);
+    sandboxInterruption.setExecutor(Executors.newSingleThreadExecutor());
+    sandboxInterruption.eval("res = 1;");
+    sandboxInterruption.inject("num", Integer.valueOf(10));
+    sandboxInterruption.eval("res = num + 1;");
+    Assert.assertEquals(Double.valueOf(11.0), sandboxInterruption.get("res"));
+    sandboxInterruption.inject("str", "20");
+    sandboxInterruption.eval("res = num + str;");
+    Assert.assertEquals("1020", sandboxInterruption.get("res"));
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestScriptInterruptionAndCatch.java
+++ b/src/test/java/delight/nashornsandbox/TestScriptInterruptionAndCatch.java
@@ -37,4 +37,30 @@ public class TestScriptInterruptionAndCatch {
       sandbox.getExecutor().shutdown();
     }
   }
+  
+  @Test(expected = ScriptCPUAbuseException.class)
+  public void test_catch_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    try {
+      sandbox.setMaxCPUTime(50);
+      sandbox.setExecutor(Executors.newSingleThreadExecutor());
+      final StringBuilder _builder = new StringBuilder();
+      _builder.append("try {\n");
+      _builder.append("\t");
+      _builder.append("var x = 1;\n");
+      _builder.append("\t");
+      _builder.append("while (true) {\n");
+      _builder.append("\t\t");
+      _builder.append("x=x+1;\n");
+      _builder.append("\t");
+      _builder.append("}\n");
+      _builder.append("} catch (e) {\n");
+      _builder.append("\t");
+      _builder.append("// if this is called, test does not succeed.\n");
+      _builder.append("}\n");
+      sandbox.eval(_builder.toString());
+    } finally {
+      sandbox.getExecutor().shutdown();
+    }
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestSetWriter.java
+++ b/src/test/java/delight/nashornsandbox/TestSetWriter.java
@@ -24,4 +24,16 @@ public class TestSetWriter {
     // javascript adds an extra carrige return.
     Assert.assertTrue("Hi there!\r\n".equals(writer.toString()) ||  "Hi there!\n".equals(writer.toString()));
   }
+  
+  @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    sandbox.allowPrintFunctions(true);
+    final StringWriter writer = new StringWriter();
+    sandbox.setWriter(writer);
+    sandbox.eval("print(\"Hi there!\");");
+    // \n at the end of the string is not enough.
+    // javascript adds an extra carrige return.
+    Assert.assertTrue("Hi there!\r\n".equals(writer.toString()) ||  "Hi there!\n".equals(writer.toString()));
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestSimpleEval.java
+++ b/src/test/java/delight/nashornsandbox/TestSimpleEval.java
@@ -17,4 +17,11 @@ public class TestSimpleEval {
     final Object res = sandbox.eval("var x = 1 + 1; x;");
     Assert.assertEquals(Integer.valueOf(2), res);
   }
+  
+  @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = GraalSandboxes.create();
+    final Object res = sandbox.eval("var x = 1 + 1; x;");
+    Assert.assertEquals(Integer.valueOf(2), res);
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestSwitch.java
+++ b/src/test/java/delight/nashornsandbox/TestSwitch.java
@@ -44,4 +44,37 @@ public class TestSwitch {
       sandbox.getExecutor().shutdown();
     }
   }
+  
+  @Test
+  public void test_graal() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = NashornSandboxes.create();
+    try {
+      sandbox.allowPrintFunctions(true);
+      sandbox.setMaxCPUTime(50);
+      sandbox.setExecutor(Executors.newSingleThreadExecutor());
+      final StringBuilder _builder = new StringBuilder();
+      _builder.append("var expr = \"one\";\n\n");
+      _builder.append("switch (expr) {\n");
+      _builder.append("  ");
+      _builder.append("case \"one\":\n");
+      _builder.append("    ");
+      _builder.append("// ok\n");
+      _builder.append("    ");
+      _builder.append("break;\n");
+      _builder.append("  ");
+      _builder.append("case \"two\":\n");
+      _builder.append("    ");
+      _builder.append("// ok\n");
+      _builder.append("    ");
+      _builder.append("break;\n");
+      _builder.append("  ");
+      _builder.append("default:\n");
+      _builder.append("    ");
+      _builder.append("print(\"Unknown expression\");\n");
+      _builder.append("}\n\n");
+      sandbox.eval(_builder.toString());
+    } finally {
+      sandbox.getExecutor().shutdown();
+    }
+  }
 }

--- a/src/test/java/delight/nashornsandbox/internal/JsSanitizerTest.java
+++ b/src/test/java/delight/nashornsandbox/internal/JsSanitizerTest.java
@@ -16,6 +16,7 @@ import javax.script.ScriptException;
 import org.junit.Before;
 import org.junit.Test;
 
+import delight.nashornsandbox.GraalSandboxes;
 import delight.nashornsandbox.NashornSandbox;
 import delight.nashornsandbox.NashornSandboxes;
 import delight.nashornsandbox.exceptions.BracesException;
@@ -178,7 +179,61 @@ public class JsSanitizerTest {
 	}
 	
 	@Test
+	public void test_issue_66_case1_graal() {
+		String script = "var t1 = \"(function)\";\n" + "var person={\n" + "    \"name\": \"test\"\n" + "};\n"
+				+ "print(\"t1\" + person.name);";
+
+		NashornSandbox sandbox = GraalSandboxes.create();
+		try {
+			sandbox.setMaxCPUTime(6000);
+			sandbox.setMaxMemory(50 * 1024 * 1024L);
+			sandbox.allowNoBraces(true);
+			sandbox.allowExitFunctions(true);
+			sandbox.allowGlobalsObjects(true);
+			sandbox.allowLoadFunctions(true);
+			sandbox.allowPrintFunctions(true);
+			sandbox.allowReadFunctions(true);
+			sandbox.setMaxPreparedStatements(10000);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.eval(script);
+		} catch (ScriptException e) {
+			throw new RuntimeException(e);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
+	
+	@Test
 	public void test_issue_66_case2() {
+		String script = "var name = 'n'; "+"function a() {\n" + 
+				"}\n" + 
+				"switch (name) {\n" + 
+				"    case \"s\":\n" + 
+				"    case \"n\":\n" + 
+				"}";
+
+		NashornSandbox sandbox = NashornSandboxes.create();
+		try {
+			sandbox.setMaxCPUTime(6000);
+			sandbox.setMaxMemory(50 * 1024 * 1024L);
+			sandbox.allowNoBraces(true);
+			sandbox.allowExitFunctions(true);
+			sandbox.allowGlobalsObjects(true);
+			sandbox.allowLoadFunctions(true);
+			sandbox.allowPrintFunctions(true);
+			sandbox.allowReadFunctions(true);
+			sandbox.setMaxPreparedStatements(10000);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			sandbox.eval(script);
+		} catch (ScriptException e) {
+			throw new RuntimeException(e);
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+	}
+	
+	@Test
+	public void test_issue_66_case2_graal() {
 		String script = "var name = 'n'; "+"function a() {\n" + 
 				"}\n" + 
 				"switch (name) {\n" + 


### PR DESCRIPTION
Hi Max,

This PR makes minimal changes to the NashornSandboxImpl, most modified files are test files, adding a GraalJS test for each test while leaving  the original tests unmodified. The GraalSandboxImpl inherits most features from the NashornSandboxImpl with the exception of a few overrides. It's not necessarily the cleanest solution and we can keep working with our internal fork while migrating to GraalVM, but creating and maintaining a fully separate fork/project would either require a lot of base refactoring for both projects or lead to a lot of duplicated code for the GraalJS version. The engines are similar enough in behavior that we could probably make just few backwards-compatible continuous changes (gearing it more towards GraalJS) while Oracle is phasing out Nashorn (which is static at this point) gradually and starts shipping GraalJS. Take a look and let me know what you think, feel free to make edits.
cheers