### PR TITLE
Prevent Scripts from running indefinitely

### DIFF
--- a/src/main/java/delight/nashornsandbox/internal/JsEvaluator.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsEvaluator.java
@@ -50,9 +50,11 @@ class JsEvaluator implements Runnable {
   @Override
   public void run() {
     try {
-      threadMonitor.setThreadToMonitor(Thread.currentThread());
-      result = operation.executeScriptEngineOperation(scriptEngine);
-    } 
+      boolean registered = threadMonitor.registerThreadToMonitor(Thread.currentThread());
+      if (registered) {
+        result = operation.executeScriptEngineOperation(scriptEngine);
+      }
+    }
     catch (final RuntimeException e) {
       // InterruptedException means script was successfully interrupted,
       // so no exception should be propagated

--- a/src/test/java/delight/nashornsandbox/internal/TestExecutorThreadNotSet.java
+++ b/src/test/java/delight/nashornsandbox/internal/TestExecutorThreadNotSet.java
@@ -1,0 +1,78 @@
+package delight.nashornsandbox.internal;
+
+import delight.nashornsandbox.NashornSandbox;
+import delight.nashornsandbox.NashornSandboxes;
+import junit.framework.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.script.Invocable;
+import javax.script.ScriptException;
+import java.util.concurrent.*;
+
+public class TestExecutorThreadNotSet {
+
+    private ThreadPoolExecutor executor;
+
+    @Before
+    public void setUp() {
+        // We create an executor with a queue
+        executor = new ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>()
+        );
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void executor_not_set_should_prevent_invocation_from_running_indefinitely() throws Exception {
+        // We use NashornSandbox to prevent the script from running indefinitely
+        NashornSandbox sandbox = NashornSandboxes.create();
+        sandbox.setMaxCPUTime(1000); // in millis
+        sandbox.setMaxMemory(1000 * 1000 * 10); // 10 MB
+        sandbox.allowNoBraces(false);
+        sandbox.allowPrintFunctions(true);
+        sandbox.setMaxPreparedStatements(30);
+        sandbox.setExecutor(executor);
+
+        // This is our infinite script
+        final String script = "function x(){while(true){}}\n";
+        sandbox.eval(script);
+
+        // We simulate a slow down that will prevent the JsEvaluator to register itself in the thread monitor in time
+        // The task will stay in the queue until the ThreadMonitor times out waiting for the JsEvaluator to register itself
+        CountDownLatch latch = new CountDownLatch(1);
+        executor.execute(() -> {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // The invocation will return an error as the JsEvaluator was not set in time
+        Invocable invocable = sandbox.getSandboxedInvocable();
+        Throwable t = null;
+        try {
+            invocable.invokeFunction("x");
+        } catch (ScriptException se) {
+            t = se;
+        }
+        Assert.assertNotNull(t);
+        Assert.assertTrue(t.getMessage().contains("Executor thread not set after"));
+        // the ThreadMonitor timed out, we can now let the JsEvaluator execute
+        latch.countDown();
+
+        // Since the thread monitor has stopped monitoring the JsEvaluator, we need to make sure the invoke was not performed
+        // Before this PR, the script could run indefinitely since it was not monitored anymore
+
+        // Shutdown the executor so we can easily wait for it to finish running all tasks
+        executor.shutdown();
+        boolean terminatedWithNoWaitingTasks = executor.awaitTermination(2, TimeUnit.SECONDS);
+        Assert.assertTrue(terminatedWithNoWaitingTasks);
+    }
+}

--- a/src/test/java/delight/nashornsandbox/internal/ThreadMonitorTest.java
+++ b/src/test/java/delight/nashornsandbox/internal/ThreadMonitorTest.java
@@ -16,7 +16,7 @@ public class ThreadMonitorTest {
 	public void when_run_and_threadToMonitor_set_then_do_not_wait() {
 		final ThreadMonitor threadMonitor = new ThreadMonitor(1000, 0);
 		Thread threadToMonitor = new Thread();
-		threadMonitor.setThreadToMonitor(threadToMonitor);
+		threadMonitor.registerThreadToMonitor(threadToMonitor);
 		threadMonitor.stopMonitor();
 
 		long startTime = System.currentTimeMillis();


### PR DESCRIPTION
The current version of Nashorn Sandbox does not guarantee that scripts will be stopped if they consume too much memory or CPU time.

The problem occurs when the `JsEvaluator` takes to much time to register its thread to the `ThreadMonitor`

When this issue happen the following code is executed:

```
if (threadToMonitor == null) {
  throw new IllegalStateException("Executor thread not set after " + maxCPUTime / MILI_TO_NANO + " ms");
}
```

The `ThreadMonitor` will return an error to the user. However this won't prevent the actual script to be executed. 
Even worse it will be executed without any kind of monitoring, the script can take as much time and memory it pleases him.

It would be a way better solution to not execute the script if the `ThreadMonitor` is not actively monitoring the script.