### PR TITLE
Experiment standalone nashorn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ jdk:
 
 sudo: false
 
+script:
+  - jdk_switcher use oraclejdk8
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ sudo: false
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java11-installer

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,14 @@
 			<artifactId>js-beautify</artifactId>
 			<version>1.9.0</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.openjdk.nashorn</groupId>
+			<artifactId>nashorn-core</artifactId>
+			<version>15.2</version>
+			<optional>true</optional>
+		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/main/java/delight/nashornsandbox/internal/JdkNashornClassFilter.java
+++ b/src/main/java/delight/nashornsandbox/internal/JdkNashornClassFilter.java
@@ -1,0 +1,12 @@
+package delight.nashornsandbox.internal;
+
+import jdk.nashorn.api.scripting.ClassFilter;
+
+public class JdkNashornClassFilter extends SandboxClassFilter implements ClassFilter {
+
+    @Override
+    public boolean exposeToScripts(final String className) {
+        return super.exposeToScripts(className);
+    }
+
+}

--- a/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
@@ -36,27 +36,6 @@ import delight.nashornsandbox.exceptions.BracesException;
 @SuppressWarnings("restriction")
 public class JsSanitizer {
 
-	private static final Class<?> JDK_NASHORN_ScriptObjectMirror_CLASS;
-	private static final Class<?> STANDALONE_NASHORN_ScriptObjectMirror_CLASS;
-
-	static {
-		Class<?> tmp_JDK_NASHORN_ScriptObjectMirror_CLASS = null;
-		// TODO what behavior do we want here?
-		try {
-			tmp_JDK_NASHORN_ScriptObjectMirror_CLASS = Class.forName("jdk.nashorn.api.scripting.ScriptObjectMirror");
-		} catch (ClassNotFoundException e) {
-			System.out.println("JDK Nashorn not found");
-		}
-		JDK_NASHORN_ScriptObjectMirror_CLASS= tmp_JDK_NASHORN_ScriptObjectMirror_CLASS;
-		Class<?> tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS = null;
-		try {
-			tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS = Class.forName("org.openjdk.nashorn.api.scripting.ScriptObjectMirror");
-		} catch (ClassNotFoundException e) {
-			System.out.println("Standalone Nashorn not found");
-		}
-		STANDALONE_NASHORN_ScriptObjectMirror_CLASS = tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS;
-	}
-
 	private static class PoisonPil {
 		Pattern pattern;
 		String replacement;
@@ -335,14 +314,14 @@ public class JsSanitizer {
 
     @SuppressWarnings("unchecked")
 	private static Function<String, String> beautifierAsFunction(Object beautifyScript) {
-        if (JDK_NASHORN_ScriptObjectMirror_CLASS != null && JDK_NASHORN_ScriptObjectMirror_CLASS.isInstance(beautifyScript)) {
+        if (NashornDetection.isJDKNashornScriptObjectMirror(beautifyScript)) {
 			return script -> {
 				jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) beautifyScript;
 				return (String) scriptObjectMirror.call("beautify", script, BEAUTIFY_OPTIONS);
 			};
         }
 
-        if (STANDALONE_NASHORN_ScriptObjectMirror_CLASS != null && STANDALONE_NASHORN_ScriptObjectMirror_CLASS.isInstance(beautifyScript)) {
+        if (NashornDetection.isStandaloneNashornScriptObjectMirror(beautifyScript)) {
 			return script -> {
 				org.openjdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (org.openjdk.nashorn.api.scripting.ScriptObjectMirror) beautifyScript;
 				return (String) scriptObjectMirror.call("beautify", script, BEAUTIFY_OPTIONS);

--- a/src/main/java/delight/nashornsandbox/internal/NashornDetection.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornDetection.java
@@ -36,7 +36,14 @@ public class NashornDetection {
             STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS = null;
             STANDALONE_NASHORN_ClassFilter_CLASS = null;
         }
-        // TODO add a report of what was detected and what will be used
+        if (JDK_NASHORN_ScriptObjectMirror_CLASS == null && STANDALONE_NASHORN_ScriptObjectMirror_CLASS == null) {
+            throw new RuntimeException("Neither JDK nor Standalone Nashorn was found. If running on JDK 15 or later, you must add standalone Nashorn to the classpath.");
+        }
+        logger.info("Delight-nashorn-sandbox detected that JDK Nashorn is {} and standalone Nashorn is {}, and will use {}",
+                JDK_NASHORN_ScriptObjectMirror_CLASS != null ? "present" : "absent",
+                STANDALONE_NASHORN_ScriptObjectMirror_CLASS != null ? "present" : "absent",
+                JDK_NASHORN_ScriptObjectMirror_CLASS != null ? "JDK Nashorn" : "Standalone Nashorn"
+        );
     }
 
     public static boolean isJDKNashornScriptObjectMirror(Object script) {

--- a/src/main/java/delight/nashornsandbox/internal/NashornDetection.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornDetection.java
@@ -1,0 +1,92 @@
+package delight.nashornsandbox.internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class NashornDetection {
+
+    private static final Logger logger = LoggerFactory.getLogger(NashornDetection.class);
+
+    private static final Class<?> JDK_NASHORN_ScriptObjectMirror_CLASS;
+    private static final Class<?> JDK_NASHORN_NashornScriptEngineFactory_CLASS;
+    private static final Class<?> JDK_NASHORN_ClassFilter_CLASS;
+
+    private static final Class<?> STANDALONE_NASHORN_ScriptObjectMirror_CLASS;
+    private static final Class<?> STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS;
+    private static final Class<?> STANDALONE_NASHORN_ClassFilter_CLASS;
+
+    static {
+        JDK_NASHORN_ScriptObjectMirror_CLASS = findClass("jdk.nashorn.api.scripting.ScriptObjectMirror", "JDK-provided Nashorn not found");
+        if (JDK_NASHORN_ScriptObjectMirror_CLASS != null) {
+            JDK_NASHORN_NashornScriptEngineFactory_CLASS = findClass("jdk.nashorn.api.scripting.NashornScriptEngineFactory", "");
+            JDK_NASHORN_ClassFilter_CLASS = findClass("jdk.nashorn.api.scripting.ClassFilter", "");
+        } else {
+            // no need to search for those and add more logs
+            JDK_NASHORN_NashornScriptEngineFactory_CLASS = null;
+            JDK_NASHORN_ClassFilter_CLASS = null;
+        }
+
+        STANDALONE_NASHORN_ScriptObjectMirror_CLASS = findClass("org.openjdk.nashorn.api.scripting.ScriptObjectMirror", "Standalone Nashorn not found");
+        if (STANDALONE_NASHORN_ScriptObjectMirror_CLASS == null) {
+            STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS = findClass("org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory", "");
+            STANDALONE_NASHORN_ClassFilter_CLASS = findClass("org.openjdk.nashorn.api.scripting.ClassFilter", "");
+        } else {
+            STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS = null;
+            STANDALONE_NASHORN_ClassFilter_CLASS = null;
+        }
+        // TODO add a report of what was detected and what will be used
+    }
+
+    public static boolean isJDKNashornScriptObjectMirror(Object script) {
+        return JDK_NASHORN_ScriptObjectMirror_CLASS != null && JDK_NASHORN_ScriptObjectMirror_CLASS.isInstance(script);
+    }
+
+    public static boolean isStandaloneNashornScriptObjectMirror(Object script) {
+        return STANDALONE_NASHORN_ScriptObjectMirror_CLASS != null && STANDALONE_NASHORN_ScriptObjectMirror_CLASS.isInstance(script);
+    }
+
+    public static SandboxClassFilter createSandboxClassFilter() {
+        // TODO allow to force one impl?
+        if (JDK_NASHORN_ClassFilter_CLASS != null) {
+            return new JdkNashornClassFilter();
+        }
+        if (STANDALONE_NASHORN_ClassFilter_CLASS != null) {
+            return new StandaloneNashornClassFilter();
+        }
+        throw new IllegalStateException("Neither jdk.nashorn.api.scripting.ClassFilter or org.openjdk.nashorn.api.scripting.ClassFilter is present");
+    }
+
+    // actually returns an instance of either jdk.nashorn.api.scripting.ClassFilter or org.openjdk.nashorn.api.scripting.ClassFilter
+    public static Class<?> getClassFilterClass() {
+        if (JDK_NASHORN_ClassFilter_CLASS != null) {
+            return JDK_NASHORN_ClassFilter_CLASS;
+        } else {
+            return STANDALONE_NASHORN_ClassFilter_CLASS;
+        }
+    }
+
+    // actually returns an instance of either jdk.nashorn.api.scripting.NashornScriptEngineFactory or org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory
+    public static Object getNashornScriptEngineFactory() {
+        try {
+            if (JDK_NASHORN_NashornScriptEngineFactory_CLASS != null) {
+                return JDK_NASHORN_NashornScriptEngineFactory_CLASS.getConstructor().newInstance();
+            } else if (STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS != null) {
+                return STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS.getConstructor().newInstance();
+            }
+            throw new IllegalStateException("Neither jdk.nashorn.api.scripting.NashornScriptEngineFactory or org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory is present");
+        } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Class<?> findClass(String className, String message) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            logger.debug(message);
+            return null;
+        }
+    }
+}

--- a/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
@@ -35,37 +35,6 @@ import delight.nashornsandbox.exceptions.ScriptMemoryAbuseException;
 @SuppressWarnings("restriction")
 public class NashornSandboxImpl implements NashornSandbox {
 
-	private static final Class<?> JDK_NASHORN_NashornScriptEngineFactory_CLASS;
-	private static final Class<?> JDK_NASHORN_ClassFilter_CLASS;
-	private static final Class<?> STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS;
-	private static final Class<?> STANDALONE_NASHORN_ClassFilter_CLASS;
-
-	static {
-		Class<?> tmp_JDK_NASHORN_NashornScriptEngineFactory_CLASS = null;
-		Class<?> tmp_JDK_NASHORN_ClassFilter_CLASS = null;
-		// TODO what behavior do we want here?
-		// TODO move all JDK/standalone code to some dedicated class?
-		try {
-			tmp_JDK_NASHORN_NashornScriptEngineFactory_CLASS = Class.forName("jdk.nashorn.api.scripting.NashornScriptEngineFactory");
-			tmp_JDK_NASHORN_ClassFilter_CLASS = Class.forName("jdk.nashorn.api.scripting.ClassFilter");
-		} catch (ClassNotFoundException e) {
-			System.out.println("JDK Nashorn not found");
-		}
-		JDK_NASHORN_NashornScriptEngineFactory_CLASS = tmp_JDK_NASHORN_NashornScriptEngineFactory_CLASS;
-		JDK_NASHORN_ClassFilter_CLASS = tmp_JDK_NASHORN_ClassFilter_CLASS;
-
-		Class<?> tmp_STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS = null;
-		Class<?> tmp_STANDALONE_NASHORN_ClassFilter_CLASS = null;
-		try {
-			tmp_STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS = Class.forName("org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory");
-			tmp_STANDALONE_NASHORN_ClassFilter_CLASS = Class.forName("org.openjdk.nashorn.api.scripting.ClassFilter");
-		} catch (ClassNotFoundException e) {
-			System.out.println("Standalone Nashorn not found");
-		}
-		STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS = tmp_STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS;
-		STANDALONE_NASHORN_ClassFilter_CLASS = tmp_STANDALONE_NASHORN_ClassFilter_CLASS;
-	}
-
 	static final Logger LOG = LoggerFactory.getLogger(NashornSandbox.class);
 
 	protected final SandboxClassFilter sandboxClassFilter;
@@ -132,34 +101,18 @@ public class NashornSandboxImpl implements NashornSandbox {
 	}
 
 	private SandboxClassFilter createSandboxClassFilter() {
-		if (JDK_NASHORN_ClassFilter_CLASS != null) {
-			return new JdkNashornClassFilter();
-		}
-		if (STANDALONE_NASHORN_ClassFilter_CLASS != null) {
-			return new StandaloneNashornClassFilter();
-		}
-		throw new IllegalStateException("Neither jdk.nashorn.api.scripting.ClassFilter or org.openjdk.nashorn.api.scripting.ClassFilter is present");
+		return NashornDetection.createSandboxClassFilter();
 	}
 
 	public ScriptEngine createNashornScriptEngineFactory(String ... params) {
         try {
-            Object nashornScriptEngineFactory = null;
-			Class<?> classFilterClass = null;
-			if (JDK_NASHORN_NashornScriptEngineFactory_CLASS != null) {
-				nashornScriptEngineFactory = JDK_NASHORN_NashornScriptEngineFactory_CLASS.getConstructor().newInstance();
-				classFilterClass = JDK_NASHORN_ClassFilter_CLASS;
-			} else if (STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS != null) {
-				nashornScriptEngineFactory = STANDALONE_NASHORN_NashornScriptEngineFactory_CLASS.getConstructor().newInstance();
-				classFilterClass = STANDALONE_NASHORN_ClassFilter_CLASS;
-			}
-            if (nashornScriptEngineFactory == null) {
-                throw new IllegalStateException("Neither jdk.nashorn.api.scripting.NashornScriptEngineFactory or org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory is present");
-            }
+			Object nashornScriptEngineFactory = NashornDetection.getNashornScriptEngineFactory();
+			Class<?> classFilterClass = NashornDetection.getClassFilterClass();
 
 			Method getScriptEngine = nashornScriptEngineFactory.getClass().getDeclaredMethod("getScriptEngine", String[].class, ClassLoader.class, classFilterClass);
             return (ScriptEngine) getScriptEngine.invoke(nashornScriptEngineFactory, params, this.getClass().getClassLoader(),
 					classFilterClass.cast(this.sandboxClassFilter));
-        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
 	}

--- a/src/main/java/delight/nashornsandbox/internal/SandboxClassFilter.java
+++ b/src/main/java/delight/nashornsandbox/internal/SandboxClassFilter.java
@@ -4,8 +4,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import jdk.nashorn.api.scripting.ClassFilter;
-
 /**
  * The class Filter.
  *
@@ -17,11 +15,9 @@ import jdk.nashorn.api.scripting.ClassFilter;
  * @version $Id$
  */
 @SuppressWarnings("restriction")
-public class SandboxClassFilter implements ClassFilter {
+public abstract class SandboxClassFilter {
   private final Set<Class<?>> allowed;
   private final Set<String> stringCache;
-  
-  @Override
   public boolean exposeToScripts(final String className) {
     return stringCache.contains(className);
   }

--- a/src/main/java/delight/nashornsandbox/internal/StandaloneNashornClassFilter.java
+++ b/src/main/java/delight/nashornsandbox/internal/StandaloneNashornClassFilter.java
@@ -1,0 +1,12 @@
+package delight.nashornsandbox.internal;
+
+import org.openjdk.nashorn.api.scripting.ClassFilter;
+
+public class StandaloneNashornClassFilter extends SandboxClassFilter implements ClassFilter {
+
+    @Override
+    public boolean exposeToScripts(final String className) {
+        return super.exposeToScripts(className);
+    }
+
+}

--- a/src/test/java/delight/nashornsandbox/TestAccessFunction.java
+++ b/src/test/java/delight/nashornsandbox/TestAccessFunction.java
@@ -1,29 +1,56 @@
 package delight.nashornsandbox;
 
-import java.util.function.Function;
-
-import javax.script.ScriptException;
-
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import delight.nashornsandbox.NashornSandbox;
-import delight.nashornsandbox.NashornSandboxes;
-import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import javax.script.ScriptException;
+import java.lang.reflect.InvocationTargetException;
 
 @SuppressWarnings("all")
 public class TestAccessFunction {
 
-  @Test
-  public void test_access_variable() throws ScriptCPUAbuseException, ScriptException {
+    private static final Class<?> JDK_NASHORN_ScriptObjectMirror_CLASS;
+    private static final Class<?> STANDALONE_NASHORN_ScriptObjectMirror_CLASS;
+
+    static {
+        Class<?> tmp_JDK_NASHORN_ScriptObjectMirror_CLASS = null;
+        // TODO what behavior do we want here?
+        try {
+            tmp_JDK_NASHORN_ScriptObjectMirror_CLASS = Class.forName("jdk.nashorn.api.scripting.ScriptObjectMirror");
+        } catch (ClassNotFoundException e) {
+            System.out.println("JDK Nashorn not found");
+        }
+        JDK_NASHORN_ScriptObjectMirror_CLASS= tmp_JDK_NASHORN_ScriptObjectMirror_CLASS;
+        Class<?> tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS = null;
+        try {
+            tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS = Class.forName("org.openjdk.nashorn.api.scripting.ScriptObjectMirror");
+        } catch (ClassNotFoundException e) {
+            System.out.println("Standalone Nashorn not found");
+        }
+        STANDALONE_NASHORN_ScriptObjectMirror_CLASS = tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS;
+    }
+
+    @Test
+  public void test_access_variable() throws ScriptCPUAbuseException, ScriptException, InvocationTargetException, IllegalAccessException {
     final NashornSandbox sandbox = NashornSandboxes.create();
     sandbox.eval("function callMe() { return 42; };");
     final Object _get = sandbox.get("callMe");
-    Assert.assertEquals(Integer.valueOf(42), ((ScriptObjectMirror) _get).call(this));
+    Assert.assertEquals(Integer.valueOf(42), findAndCall(_get));
     final Object _eval = sandbox.eval("callMe");
-    Assert.assertEquals(Integer.valueOf(42), ((ScriptObjectMirror) _eval).call(this));
+    Assert.assertEquals(Integer.valueOf(42), findAndCall(_get));
   }
 
-  
+    private Object findAndCall(Object _get) {
+        if (JDK_NASHORN_ScriptObjectMirror_CLASS != null && JDK_NASHORN_ScriptObjectMirror_CLASS.isInstance(_get)) {
+            jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) _get;
+            return scriptObjectMirror.call(_get);
+        }
+
+        if (STANDALONE_NASHORN_ScriptObjectMirror_CLASS != null && STANDALONE_NASHORN_ScriptObjectMirror_CLASS.isInstance(_get)) {
+            org.openjdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (org.openjdk.nashorn.api.scripting.ScriptObjectMirror) _get;
+            return scriptObjectMirror.call(_get);
+        }
+        throw new IllegalStateException("Neither JDK nor standalone Nashorn has been found");
+    }
 }

--- a/src/test/java/delight/nashornsandbox/TestAccessFunction.java
+++ b/src/test/java/delight/nashornsandbox/TestAccessFunction.java
@@ -1,6 +1,7 @@
 package delight.nashornsandbox;
 
 import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+import delight.nashornsandbox.internal.NashornDetection;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -9,27 +10,6 @@ import java.lang.reflect.InvocationTargetException;
 
 @SuppressWarnings("all")
 public class TestAccessFunction {
-
-    private static final Class<?> JDK_NASHORN_ScriptObjectMirror_CLASS;
-    private static final Class<?> STANDALONE_NASHORN_ScriptObjectMirror_CLASS;
-
-    static {
-        Class<?> tmp_JDK_NASHORN_ScriptObjectMirror_CLASS = null;
-        // TODO what behavior do we want here?
-        try {
-            tmp_JDK_NASHORN_ScriptObjectMirror_CLASS = Class.forName("jdk.nashorn.api.scripting.ScriptObjectMirror");
-        } catch (ClassNotFoundException e) {
-            System.out.println("JDK Nashorn not found");
-        }
-        JDK_NASHORN_ScriptObjectMirror_CLASS= tmp_JDK_NASHORN_ScriptObjectMirror_CLASS;
-        Class<?> tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS = null;
-        try {
-            tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS = Class.forName("org.openjdk.nashorn.api.scripting.ScriptObjectMirror");
-        } catch (ClassNotFoundException e) {
-            System.out.println("Standalone Nashorn not found");
-        }
-        STANDALONE_NASHORN_ScriptObjectMirror_CLASS = tmp_STANDALONE_NASHORN_ScriptObjectMirror_CLASS;
-    }
 
     @Test
   public void test_access_variable() throws ScriptCPUAbuseException, ScriptException, InvocationTargetException, IllegalAccessException {
@@ -42,12 +22,12 @@ public class TestAccessFunction {
   }
 
     private Object findAndCall(Object _get) {
-        if (JDK_NASHORN_ScriptObjectMirror_CLASS != null && JDK_NASHORN_ScriptObjectMirror_CLASS.isInstance(_get)) {
+        if (NashornDetection.isJDKNashornScriptObjectMirror(_get)) {
             jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) _get;
             return scriptObjectMirror.call(_get);
         }
 
-        if (STANDALONE_NASHORN_ScriptObjectMirror_CLASS != null && STANDALONE_NASHORN_ScriptObjectMirror_CLASS.isInstance(_get)) {
+        if (NashornDetection.isStandaloneNashornScriptObjectMirror(_get)) {
             org.openjdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (org.openjdk.nashorn.api.scripting.ScriptObjectMirror) _get;
             return scriptObjectMirror.call(_get);
         }

--- a/src/test/java/delight/nashornsandbox/TestIssue57.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue57.java
@@ -1,12 +1,12 @@
 package delight.nashornsandbox;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.script.ScriptException;
-
+import delight.nashornsandbox.internal.NashornSandboxImpl;
 import org.junit.Test;
 
-import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * See https://github.com/javadelight/delight-nashorn-sandbox/issues/57
@@ -22,7 +22,8 @@ public class TestIssue57 {
 		String script = "[1,2,3,4].map(function(n){return n+1}).reduce(function(prev,cur){return prev+cur}, 0)";
 		String[] NASHORN_ARGS = { "--no-java", "--no-syntax-extensions" };
 
-		Double nashornResult = (Double) new NashornScriptEngineFactory().getScriptEngine(NASHORN_ARGS).eval(script);
+		ScriptEngine scriptEngine = new NashornSandboxImpl().createNashornScriptEngineFactory(NASHORN_ARGS);
+		Double nashornResult = (Double) scriptEngine.eval(script);
 		assertEquals(14, nashornResult.intValue());
 
 		Double sandboxResults = (Double) NashornSandboxes.create(NASHORN_ARGS).eval(script);

--- a/src/test/java/delight/nashornsandbox/internal/JsSanitizerTest.java
+++ b/src/test/java/delight/nashornsandbox/internal/JsSanitizerTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.fail;
 import java.util.concurrent.Executors;
 
 import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 
 import org.junit.Before;
@@ -33,7 +32,7 @@ public class JsSanitizerTest {
 	private final ScriptEngine scriptEngine;
 
 	public JsSanitizerTest() {
-		scriptEngine = new ScriptEngineManager().getEngineByName("nashorn");
+		scriptEngine = new NashornSandboxImpl().createNashornScriptEngineFactory();
 	}
 
 	@Before


### PR DESCRIPTION
Oups, that was meant to be a draft for discussion about https://github.com/javadelight/delight-nashorn-sandbox/issues/109, please treat it as the basis for discussion and not a serious PR.

What I think needs more effort:
- [ ] cleanup the code
- [ ] as standalone nashorn builds on JDK 11, what should we do? Some suggestions: 
1- build on 11 targeting 8
2- raise the minimal version to 11 (probably not the best solution)
3- split in another module so the core builds on 8 and the module for standalone nashorn builds on 11
- [ ] find a test strategy to test on at least JDK 8, 11 and 15, maybe with a bunch of modules targeting each of these versions?