### PR TITLE
Add support for compiling scripts & executing pre-compiled scripts.

### DIFF
--- a/src/main/java/delight/nashornsandbox/NashornSandbox.java
+++ b/src/main/java/delight/nashornsandbox/NashornSandbox.java
@@ -1,15 +1,15 @@
 package delight.nashornsandbox;
 
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.concurrent.ExecutorService;
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 import javax.script.Bindings;
+import javax.script.CompiledScript;
 import javax.script.Invocable;
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
-
-import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.concurrent.ExecutorService;
 
 /**
  * The Nashorn sandbox interface.
@@ -294,4 +294,21 @@ public interface NashornSandbox {
    * @param cache the new cache to use
    */
   void setScriptCache(SecuredJsCache cache);
+
+  /**
+   * Compile the JavaScript string
+   *
+   * @param js the JavaScript script to be compiled
+   * @return a CompiledScript object
+   * @throws ScriptException
+   */
+  CompiledScript compile(final String js) throws ScriptException;
+
+  /**
+   * Run a pre-compiled JavaScript
+   */
+  Object eval(CompiledScript compiledScript) throws ScriptCPUAbuseException, ScriptException;
+  Object eval(CompiledScript compiledScript, Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
+  Object eval(CompiledScript compiledScript, ScriptContext scriptContext) throws ScriptCPUAbuseException, ScriptException;
+  Object eval(CompiledScript compiledScript, ScriptContext scriptContext,Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
 }

--- a/src/main/java/delight/nashornsandbox/internal/EvaluateCompiledOperation.java
+++ b/src/main/java/delight/nashornsandbox/internal/EvaluateCompiledOperation.java
@@ -1,0 +1,52 @@
+package delight.nashornsandbox.internal;
+
+import javax.script.Bindings;
+import javax.script.CompiledScript;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import static delight.nashornsandbox.internal.NashornSandboxImpl.LOG;
+
+public class EvaluateCompiledOperation implements ScriptEngineOperation {
+
+	private final CompiledScript compiledScript;
+	private final ScriptContext scriptContext;
+	private final Bindings bindings;
+
+	public CompiledScript getCompiledScript() {
+		return compiledScript;
+	}
+
+	public ScriptContext getScriptContext() {
+		return scriptContext;
+	}
+
+	public Bindings getBindings() {
+		return bindings;
+	}
+
+	public EvaluateCompiledOperation(CompiledScript compiledScript, ScriptContext scriptContext, Bindings bindings) {
+		this.compiledScript = compiledScript;
+		this.scriptContext = scriptContext;
+		this.bindings = bindings;
+	}
+
+	@Override
+	public Object executeScriptEngineOperation(ScriptEngine scriptEngine) throws ScriptException
+	{
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("--- Running Compiled JS ---");
+			LOG.debug(compiledScript.toString());
+			LOG.debug("--- Compiled JS END ---");
+		}
+
+		if (bindings != null) {
+			return compiledScript.eval(bindings);
+		} else if (scriptContext != null) {
+			return compiledScript.eval(scriptContext);
+		} else {
+			return compiledScript.eval();
+		}
+	}
+}

--- a/src/test/java/delight/nashornsandbox/TestAllowAndDisallowClasses.java
+++ b/src/test/java/delight/nashornsandbox/TestAllowAndDisallowClasses.java
@@ -1,14 +1,14 @@
 package delight.nashornsandbox;
 
-import java.io.File;
-import java.util.Objects;
-
-import javax.script.ScriptException;
-
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+import delight.nashornsandbox.internal.InterruptTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+import javax.script.CompiledScript;
+import javax.script.ScriptException;
+import java.io.File;
+import java.util.Objects;
 
 @SuppressWarnings("all")
 public class TestAllowAndDisallowClasses {
@@ -45,5 +45,38 @@ public class TestAllowAndDisallowClasses {
     }
   }
 
-  
+  @Test
+  public void test_file_compiled() throws ScriptException {
+    final NashornSandbox sandbox = NashornSandboxes.create();
+    final String testClassScript = "var File = Java.type(\"java.io.File\"); File;";
+    sandbox.allow(File.class);
+    sandbox.compile(testClassScript).eval();
+    boolean _isAllowed = sandbox.isAllowed(File.class);
+    boolean _not = (!_isAllowed);
+    if (_not) {
+      Assert.fail("Expected class File is allowed.");
+    }
+    sandbox.disallow(File.class);
+    try {
+      sandbox.compile(testClassScript).eval();
+      Assert.fail("When disallow the File class expected a ClassNotFoundException!");
+    } catch (final RuntimeException e) {
+      if (((!(e.getCause() instanceof ClassNotFoundException)) || (!Objects.equals(e.getCause().getMessage(), "java.io.File")))) {
+        throw e;
+      }
+    }
+    sandbox.allow(File.class);
+    sandbox.compile(testClassScript).eval();
+    sandbox.disallowAllClasses();
+    sandbox.allow(InterruptTest.class);
+    try {
+      CompiledScript compiled = sandbox.compile(testClassScript);
+      sandbox.eval(compiled);
+      Assert.fail("When disallow all classes expected a ClassNotFoundException!");
+    } catch (final RuntimeException e) {
+      if (((!(e.getCause() instanceof ClassNotFoundException)) || (!Objects.equals(e.getCause().getMessage(), "java.io.File")))) {
+        throw e;
+      }
+    }
+  }
 }

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptBindings.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptBindings.java
@@ -28,7 +28,24 @@ public class TestEvalWithScriptBindings {
     Assert.assertTrue(res2.equals(Double.valueOf("5.0")) || res2.equals(new Integer(5)) );
     
   }
-  
+
+  @Test
+  public void test_compiled() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = NashornSandboxes.create();
+    Bindings binding1 = sandbox.createBindings();
+    binding1.put("y", 2);
+
+    Bindings binding2 = sandbox.createBindings();
+    binding2.put("y", 4);
+
+    final Object res1 = sandbox.eval(sandbox.compile("function cal() {var x = y + 1; return x;} cal();"), binding1);
+    Assert.assertTrue(res1.equals(Double.valueOf("3.0")) || res1.equals(new Integer(3)));
+
+    final Object res2 = sandbox.eval(sandbox.compile("function cal() {var x = y + 1; return x;} cal();"), binding2);
+    Assert.assertTrue(res2.equals(Double.valueOf("5.0")) || res2.equals(new Integer(5)) );
+
+  }
+
   @Test
   public void testWithCPUAndMemory() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContext.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContext.java
@@ -31,7 +31,24 @@ public class TestEvalWithScriptContext {
     final Object res2 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext2);
     Assert.assertTrue(res2.equals(Double.valueOf("5.0")) || res2.equals(new Integer(5)));
   }
-  
+
+  @Test
+  public void test_compiled() throws ScriptCPUAbuseException, ScriptException {
+    final NashornSandbox sandbox = NashornSandboxes.create();
+    ScriptContext newContext1 = new SimpleScriptContext();
+    Bindings engineScope1 = newContext1.getBindings(ScriptContext.ENGINE_SCOPE);
+    engineScope1.put("y", 2);
+
+    ScriptContext newContext2 = new SimpleScriptContext();
+    Bindings engineScope2 = newContext2.getBindings(ScriptContext.ENGINE_SCOPE);
+    engineScope2.put("y", 4);
+
+    final Object res1 = sandbox.eval(sandbox.compile("function cal() {var x = y + 1; return x;} cal();"), newContext1);
+    Assert.assertTrue(res1.equals(Double.valueOf("3.0")) || res1.equals(new Integer(3)));
+
+    final Object res2 = sandbox.eval(sandbox.compile("function cal() {var x = y + 1; return x;} cal();"), newContext2);
+    Assert.assertTrue(res2.equals(Double.valueOf("5.0")) || res2.equals(new Integer(5)));
+  }
   
   @Test
   public void testWithCPUAndMemory() throws ScriptCPUAbuseException, ScriptException {

--- a/src/test/java/delight/nashornsandbox/TestScriptInterruptionAndCatch.java
+++ b/src/test/java/delight/nashornsandbox/TestScriptInterruptionAndCatch.java
@@ -1,12 +1,12 @@
 package delight.nashornsandbox;
 
-import java.util.concurrent.Executors;
-
-import javax.script.ScriptException;
-
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+import junit.framework.Assert;
 import org.junit.Test;
 
-import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+import javax.script.CompiledScript;
+import javax.script.ScriptException;
+import java.util.concurrent.Executors;
 
 @SuppressWarnings("all")
 public class TestScriptInterruptionAndCatch {
@@ -36,4 +36,66 @@ public class TestScriptInterruptionAndCatch {
 		}
 	}
 
+	@Test(expected = ScriptCPUAbuseException.class)
+	public void test_catch_compiled() throws ScriptException {
+		final NashornSandbox sandbox = NashornSandboxes.create();
+		try
+		{
+			sandbox.setMaxCPUTime(50);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			final StringBuilder _builder = new StringBuilder();
+			_builder.append("try {\n");
+			_builder.append("\t");
+			_builder.append("var x = 1;\n");
+			_builder.append("\t");
+			_builder.append("while (true) {\n");
+			_builder.append("\t\t");
+			_builder.append("x=x+1;\n");
+			_builder.append("\t");
+			_builder.append("}\n");
+			_builder.append("} catch (e) {\n");
+			_builder.append("\t");
+			_builder.append("// if this is called, test does not succeed.\n");
+			_builder.append("}\n");
+			CompiledScript compiled = sandbox.compile(_builder.toString());
+			sandbox.eval(compiled);
+		}
+		finally
+		{
+			sandbox.getExecutor().shutdown();
+		}
+	}
+
+	@Test
+	public void test_engine_working_after_crash() throws ScriptException {
+		final NashornSandbox sandbox = NashornSandboxes.create();
+		CompiledScript validScript = null;
+		validScript = sandbox.compile("1+1;");
+		try {
+			sandbox.setMaxCPUTime(50);
+			sandbox.setExecutor(Executors.newSingleThreadExecutor());
+			final StringBuilder _builder = new StringBuilder();
+			_builder.append("try {\n");
+			_builder.append("\t");
+			_builder.append("var x = 1;\n");
+			_builder.append("\t");
+			_builder.append("while (true) {\n");
+			_builder.append("\t\t");
+			_builder.append("x=x+1;\n");
+			_builder.append("\t");
+			_builder.append("}\n");
+			_builder.append("} catch (e) {\n");
+			_builder.append("\t");
+			_builder.append("// if this is called, test does not succeed.\n");
+			_builder.append("}\n");
+			CompiledScript compiled = sandbox.compile(_builder.toString());
+			sandbox.eval(compiled);
+		} catch (Exception e) {
+			Assert.assertEquals(ScriptCPUAbuseException.class, e.getClass());
+		} finally {
+			sandbox.getExecutor().shutdown();
+		}
+		sandbox.setExecutor(Executors.newSingleThreadExecutor());
+		Assert.assertEquals(2, validScript.eval());
+	}
 }


### PR DESCRIPTION
Hi,
The goal of this change is to increase performance by precompiling the sanitized JS.
Use-case: an application which runs the same JS script many times, and requires low latency.

```
class Example
{
  NashornSandbox m_sandbox = NashornSandbox.create();
  CompiledScript m_precompiled = sandbox.compile("1 + 1");

  public int doSomething()
  {
     return (int)m_sandbox.eval(m_precompiled);
  }
```
