### PR TITLE
Ensuring only safe script contexts are passed into the engine

### DIFF
--- a/.project
+++ b/.project
@@ -28,12 +28,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1602570532382</id>
+			<id>1675032386265</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ for JS evaluation and better handling of monitoring for threads for possible CPU
 
 ## Version History
 
+- 0.3.0: Creating a wrapper for Script Context to be passed to eval to avoid accidental exposure. Resolves [Issue #134](https://github.com/javadelight/delight-nashorn-sandbox/issues/134)
 - 0.2.5: Support for pre-compiled scripts ([PR #119](https://github.com/javadelight/delight-nashorn-sandbox/pull/119) by [geoffreyharding](https://github.com/geoffreyharding)]
 - 0.2.4: Increased resiliency for killing threads under high load ([PR #118](https://github.com/javadelight/delight-nashorn-sandbox/pull/118) by [tellmewhattodo](https://github.com/tellmewhattodo))
 - 0.2.0: Dynamically detects what version of the JDK the library is run with, and will either use the included Nashorn version or use Nashorn dependency ([Issue #109](https://github.com/javadelight/delight-nashorn-sandbox/issues/109), [PR #101](https://github.com/javadelight/delight-nashorn-sandbox/pull/111)).

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.javadelight</groupId>
 	<artifactId>delight-nashorn-sandbox</artifactId>
-	<version>0.2.5</version>
+	<version>0.3.0</version>
 	<description>A safe sandbox to execute JavaScript code from Nashorn.</description>
 	<url>https://github.com/javadelight/delight-nashorn-sandbox</url>
 

--- a/src/main/java/delight/nashornsandbox/NashornSandbox.java
+++ b/src/main/java/delight/nashornsandbox/NashornSandbox.java
@@ -133,7 +133,7 @@ public interface NashornSandbox {
    * @throws ScriptException when script syntax error occurs
    * @see #setMaxCPUTime(long)
    */
-  Object eval(String js,Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
+  Object eval(String js, Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
 
   /**
    * Evaluates the JavaScript string for a given script context
@@ -145,7 +145,7 @@ public interface NashornSandbox {
    * @throws ScriptException when script syntax error occurs
    * @see #setMaxCPUTime(long)
    */
-  Object eval(String js, ScriptContext scriptContext) throws ScriptCPUAbuseException, ScriptException;
+  Object eval(String js, SandboxScriptContext scriptContext) throws ScriptCPUAbuseException, ScriptException;
 
 
   /**
@@ -159,7 +159,7 @@ public interface NashornSandbox {
    * @throws ScriptException when script syntax error occurs
    * @see #setMaxCPUTime(long)
    */
-  Object eval(String js, ScriptContext scriptContext,Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
+  Object eval(String js, SandboxScriptContext scriptContext,Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
   
   /**
    * Obtains the value of the specified JavaScript variable.
@@ -310,5 +310,11 @@ public interface NashornSandbox {
   Object eval(CompiledScript compiledScript) throws ScriptCPUAbuseException, ScriptException;
   Object eval(CompiledScript compiledScript, Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
   Object eval(CompiledScript compiledScript, ScriptContext scriptContext) throws ScriptCPUAbuseException, ScriptException;
-  Object eval(CompiledScript compiledScript, ScriptContext scriptContext,Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
+  Object eval(CompiledScript compiledScript, ScriptContext scriptContext, Bindings bindings) throws ScriptCPUAbuseException, ScriptException;
+
+  /**
+ * Create a new secured script context
+ */
+SandboxScriptContext createScriptContext();
+
 }

--- a/src/main/java/delight/nashornsandbox/SandboxScriptContext.java
+++ b/src/main/java/delight/nashornsandbox/SandboxScriptContext.java
@@ -1,0 +1,8 @@
+package delight.nashornsandbox;
+
+import javax.script.ScriptContext;
+
+public interface SandboxScriptContext {
+
+  public ScriptContext getContext();
+}

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContext.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContext.java
@@ -17,12 +17,12 @@ public class TestEvalWithScriptContext {
   @Test
   public void test() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
-    ScriptContext newContext1 = new SimpleScriptContext();
-    Bindings engineScope1 = newContext1.getBindings(ScriptContext.ENGINE_SCOPE);
+    SandboxScriptContext newContext1 = sandbox.createScriptContext(); 
+    Bindings engineScope1 = newContext1.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
     engineScope1.put("y", 2);
     
-    ScriptContext newContext2 = new SimpleScriptContext();
-    Bindings engineScope2 = newContext2.getBindings(ScriptContext.ENGINE_SCOPE);
+    SandboxScriptContext newContext2 = sandbox.createScriptContext();
+    Bindings engineScope2 = newContext2.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
     engineScope2.put("y", 4);
     
     final Object res1 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext1);
@@ -56,12 +56,12 @@ public class TestEvalWithScriptContext {
     sandbox.setMaxCPUTime(100);
     sandbox.setMaxMemory(1000 * 1024);
     sandbox.setExecutor(Executors.newSingleThreadExecutor());
-    ScriptContext newContext1 = new SimpleScriptContext();
-    Bindings engineScope1 = newContext1.getBindings(ScriptContext.ENGINE_SCOPE);
+    SandboxScriptContext newContext1 = sandbox.createScriptContext();
+    Bindings engineScope1 = newContext1.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
     engineScope1.put("y", 2);
     
-    ScriptContext newContext2 = new SimpleScriptContext();
-    Bindings engineScope2 = newContext2.getBindings(ScriptContext.ENGINE_SCOPE);
+    SandboxScriptContext newContext2 = sandbox.createScriptContext();
+    Bindings engineScope2 = newContext2.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
     engineScope2.put("y", 4);
     
     final Object res1 = sandbox.eval("function cal() {var x = y + 1; return x;} cal();", newContext1);

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithNewBindings.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithNewBindings.java
@@ -37,11 +37,11 @@ public class TestEvalWithScriptContextWithNewBindings {
 	@Test
 	public void testWithNewBindingsScriptContext() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
-		ScriptContext newContext = new SimpleScriptContext();
+		SandboxScriptContext newContext = sandbox.createScriptContext();
 		// Create new binding to override the ECMAScript Global properties 
 		Bindings newBinding = sandbox.createBindings();
 		newBinding.put("Date", "2112018");
-		newContext.setBindings(newBinding, ScriptContext.ENGINE_SCOPE);
+		newContext.getContext().setBindings(newBinding, ScriptContext.ENGINE_SCOPE);
 
 		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newContext);
     Assert.assertTrue(res.equals(Double.valueOf("2112018.0")) || res.equals(Integer.valueOf(2112018)));
@@ -50,14 +50,12 @@ public class TestEvalWithScriptContextWithNewBindings {
 	@Test
 	public void testWithExistingBindings() throws ScriptCPUAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
-		ScriptContext newContext = new SimpleScriptContext();
-		Bindings newBinding = newContext.getBindings(ScriptContext.ENGINE_SCOPE);
-		// This will not be updated by using existing bindings, since Date is a 
-		// ECMAScript "global" properties and it is being in ENGINE_SCOPE
+		SandboxScriptContext newContext = sandbox.createScriptContext();
+		Bindings newBinding = newContext.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
 		newBinding.put("Date", "2112018");
 
 		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newContext);
-		Assert.assertTrue(Double.isNaN((Double)res));
+		Assert.assertTrue(res.equals(2112018));
 	}
 	
 	

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithVariables.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithVariables.java
@@ -16,8 +16,8 @@ public class TestEvalWithScriptContextWithVariables {
   @Test
   public void test() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
-    ScriptContext newContext1 = new SimpleScriptContext();
-    ScriptContext newContext2 = new SimpleScriptContext();
+    SandboxScriptContext newContext1 = sandbox.createScriptContext(); 
+    SandboxScriptContext newContext2 = sandbox.createScriptContext();
     
     sandbox.eval("function cal() {var x = 1; return x;}", newContext1);
     sandbox.eval("function cal() {var x = 2; return x;}", newContext2);
@@ -36,8 +36,8 @@ public class TestEvalWithScriptContextWithVariables {
     sandbox.setMaxCPUTime(100);
     sandbox.setMaxMemory(1000 * 1024);
     sandbox.setExecutor(Executors.newSingleThreadExecutor());
-    ScriptContext newContext1 = new SimpleScriptContext();
-    ScriptContext newContext2 = new SimpleScriptContext();
+    SandboxScriptContext newContext1 = sandbox.createScriptContext();
+    SandboxScriptContext newContext2 = sandbox.createScriptContext();
     
     sandbox.eval("function cal() {var x = 1; return x;}", newContext1);
     sandbox.eval("function cal() {var x = 2; return x;}", newContext2);

--- a/src/test/java/delight/nashornsandbox/TestExit.java
+++ b/src/test/java/delight/nashornsandbox/TestExit.java
@@ -34,11 +34,10 @@ public class TestExit {
   
   
 
-  @Test
-  @Ignore("This will fail as there is no confirmation on Script Contexts")
+  @Test(expected = javax.script.ScriptException.class)
   public void testQuitWithScriptContext() throws ScriptCPUAbuseException, ScriptException {
     final NashornSandbox sandbox = NashornSandboxes.create();
-    sandbox.eval("quit();", new SimpleScriptContext());
+    sandbox.eval("quit();", sandbox.createScriptContext());
   }
   
  

--- a/src/test/java/delight/nashornsandbox/TestIssue134.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue134.java
@@ -3,7 +3,9 @@ package delight.nashornsandbox;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import javax.script.ScriptContext;
 import javax.script.ScriptException;
+import javax.script.SimpleScriptContext;
 
 import org.junit.Test;
 
@@ -11,12 +13,12 @@ import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
 
 public class TestIssue134 {
 
-	@Test
+	@Test(expected = javax.script.ScriptException.class)
 	public void test() throws ScriptCPUAbuseException, ScriptException {
 		NashornSandbox sandbox = NashornSandboxes.create();
-
-		sandbox.eval("load('classpath:TestIssue134.js')");
-		sandbox.eval("load('somethingwrong')");
+		SandboxScriptContext context = sandbox.createScriptContext();
+		sandbox.eval("load('classpath:TestIssue134.js')", context);
+		sandbox.eval("load('somethingwrong')", context);
 	}
 
 }

--- a/src/test/java/delight/nashornsandbox/TestIssue134.java
+++ b/src/test/java/delight/nashornsandbox/TestIssue134.java
@@ -1,0 +1,22 @@
+package delight.nashornsandbox;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.script.ScriptException;
+
+import org.junit.Test;
+
+import delight.nashornsandbox.exceptions.ScriptCPUAbuseException;
+
+public class TestIssue134 {
+
+	@Test
+	public void test() throws ScriptCPUAbuseException, ScriptException {
+		NashornSandbox sandbox = NashornSandboxes.create();
+
+		sandbox.eval("load('classpath:TestIssue134.js')");
+		sandbox.eval("load('somethingwrong')");
+	}
+
+}

--- a/src/test/resources/TestIssue134.js
+++ b/src/test/resources/TestIssue134.js
@@ -1,2 +1,2 @@
-console.log('loaded');
+print('loaded');
 throw new Error('I should never be called!');

--- a/src/test/resources/TestIssue134.js
+++ b/src/test/resources/TestIssue134.js
@@ -1,0 +1,2 @@
+console.log('loaded');
+throw new Error('I should never be called!');


### PR DESCRIPTION
Resolves #134

Introduces a wrapper object for defining a script context. This ensures that the script context is always properly initialised. 