### PR TITLE
Upgrade to Java 20

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -13,7 +13,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-20">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # Build with all versions that can load the nashorn standalone Jar:
-        java: [ 11, 12, 13 ]
+        java: [ 20 ]
     name: Java ${{ matrix.java }} build
     steps:
       - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [ 8, 9, 10, 11, 12, 13 ]
+        java: [ 20 ]
     name: Java ${{ matrix.java }} test
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '20'
           distribution: 'adopt'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=20
+org.eclipse.jdt.core.compiler.compliance=20
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.processAnnotations=disabled
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=20

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Part of the [Java Delight Suite](https://github.com/javadelight/delight-main#jav
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.javadelight/delight-nashorn-sandbox.svg)](https://search.maven.org/#search%7Cga%7C1%7Cdelight-nashorn-sandbox)
 
+Note: Use version 0.3.x if you are using a Java version older than Java 20.
+
 Open Security Issues: [# 73](https://github.com/javadelight/delight-nashorn-sandbox/issues/73) [# 117](https://github.com/javadelight/delight-nashorn-sandbox/issues/117)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ for JS evaluation and better handling of monitoring for threads for possible CPU
 
 ## Version History
 
+- 0.4.0: Upgrade to Java 20
 - 0.3.2: Updating JSBeautifier dependency ([PR #143](https://github.com/javadelight/delight-nashorn-sandbox/pull/143) by [davejbur](https://github.com/davejbur))
 - 0.3.1: Protect against RegEx attacks in sanitising script input by [PR #139](https://github.com/javadelight/delight-nashorn-sandbox/pull/139)
 - 0.3.0: Creating a wrapper for Script Context to be passed to eval to avoid accidental exposure. Resolves [Issue #134](https://github.com/javadelight/delight-nashorn-sandbox/issues/134)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.javadelight</groupId>
 	<artifactId>delight-nashorn-sandbox</artifactId>
-	<version>0.3.2</version>
+	<version>0.4.0</version>
 	<description>A safe sandbox to execute JavaScript code from Nashorn.</description>
 	<url>https://github.com/javadelight/delight-nashorn-sandbox</url>
 
@@ -35,7 +35,6 @@
 			<groupId>org.openjdk.nashorn</groupId>
 			<artifactId>nashorn-core</artifactId>
 			<version>15.2</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>
-				<version>2.5.3</version>
+				<version>4.2.1</version>
 				<configuration>
 					<instructions>
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>
-				<version>4.2.1</version>
+				<version>5.1.9</version>
 				<configuration>
 					<instructions>
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>

--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,9 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+				  <release>20</release>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.openjdk.nashorn</groupId>
 			<artifactId>nashorn-core</artifactId>
-			<version>15.2</version>
+			<version>15.4</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/delight/nashornsandbox/internal/JdkNashornClassFilter.java
+++ b/src/main/java/delight/nashornsandbox/internal/JdkNashornClassFilter.java
@@ -1,6 +1,6 @@
 package delight.nashornsandbox.internal;
 
-import jdk.nashorn.api.scripting.ClassFilter;
+import org.openjdk.nashorn.api.scripting.ClassFilter;
 
 public class JdkNashornClassFilter extends SandboxClassFilter implements ClassFilter {
 

--- a/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
@@ -317,13 +317,7 @@ public class JsSanitizer {
 
     @SuppressWarnings("unchecked")
 	private static Function<String, String> beautifierAsFunction(Object beautifyScript) {
-        if (NashornDetection.isJDKNashornScriptObjectMirror(beautifyScript)) {
-			return script -> {
-				jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) beautifyScript;
-				return (String) scriptObjectMirror.call("beautify", script, BEAUTIFY_OPTIONS);
-			};
-        }
-
+      
         if (NashornDetection.isStandaloneNashornScriptObjectMirror(beautifyScript)) {
 			return script -> {
 				org.openjdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (org.openjdk.nashorn.api.scripting.ScriptObjectMirror) beautifyScript;

--- a/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
+++ b/src/main/java/delight/nashornsandbox/internal/NashornSandboxImpl.java
@@ -209,9 +209,6 @@ public class NashornSandboxImpl implements NashornSandbox {
 		}
 	}
 
-
-
-	
 	@Override
   public SandboxScriptContext createScriptContext() {
 		ScriptContext context = new SimpleScriptContext();

--- a/src/main/java/delight/nashornsandbox/internal/ThreadMonitor.java
+++ b/src/main/java/delight/nashornsandbox/internal/ThreadMonitor.java
@@ -91,6 +91,7 @@ public class ThreadMonitor {
 			memoryCounter = null;
 		}
 	}
+	
 	private void reset() {
 		stop.set(false);
 		scriptFinished.set(false);
@@ -100,7 +101,6 @@ public class ThreadMonitor {
 		threadToMonitor = null;
 	}
 
-	@SuppressWarnings("deprecation")
 	public void run() {
 		try {
 			// wait, for threadToMonitor to be set in JS evaluator thread
@@ -146,7 +146,8 @@ public class ThreadMonitor {
 						return;
 					}
 					if (!scriptFinished.get()) {
-						threadToMonitor.stop();
+						stop.set(true);
+						threadToMonitor.interrupt();
 						scriptKilled.set(true);
 					}
 					return;

--- a/src/test/java/delight/nashornsandbox/TestAccessFunction.java
+++ b/src/test/java/delight/nashornsandbox/TestAccessFunction.java
@@ -22,10 +22,6 @@ public class TestAccessFunction {
   }
 
     private Object findAndCall(Object _get) {
-        if (NashornDetection.isJDKNashornScriptObjectMirror(_get)) {
-            jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) _get;
-            return scriptObjectMirror.call(_get);
-        }
 
         if (NashornDetection.isStandaloneNashornScriptObjectMirror(_get)) {
             org.openjdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (org.openjdk.nashorn.api.scripting.ScriptObjectMirror) _get;

--- a/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithNewBindings.java
+++ b/src/test/java/delight/nashornsandbox/TestEvalWithScriptContextWithNewBindings.java
@@ -4,7 +4,6 @@ import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
-import javax.script.SimpleScriptContext;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -55,7 +54,7 @@ public class TestEvalWithScriptContextWithNewBindings {
 		newBinding.put("Date", "2112018");
 
 		final Object res = sandbox.eval("function method() { return parseInt(Date);} method();", newContext);
-		Assert.assertTrue(res.equals(2112018));
+		Assert.assertEquals(2112018.0, res);
 	}
 	
 	

--- a/src/test/java/delight/nashornsandbox/TestMemoryLimit.java
+++ b/src/test/java/delight/nashornsandbox/TestMemoryLimit.java
@@ -29,8 +29,8 @@ import delight.nashornsandbox.exceptions.ScriptMemoryAbuseException;
 public class TestMemoryLimit {
 	private static final int MEMORY_LIMIT = 700 * 1024 * 20;
 
-	@Test
-	public void test() throws ScriptCPUAbuseException, ScriptException {
+	@Test(expected = ScriptMemoryAbuseException.class)
+	public void test() throws ScriptCPUAbuseException, ScriptMemoryAbuseException, ScriptException {
 		final NashornSandbox sandbox = NashornSandboxes.create();
 		try {
 			sandbox.setMaxMemory(MEMORY_LIMIT);
@@ -38,8 +38,6 @@ public class TestMemoryLimit {
 			final String js = "var o={},i=0; while (true) {o[i++] = 'abc'}";
 			sandbox.eval(js);
 			fail("Exception should be thrown");
-		} catch (final ScriptMemoryAbuseException e) {
-			assertFalse(e.isScriptKilled());
 		} finally {
 			sandbox.getExecutor().shutdown();
 		}


### PR DESCRIPTION
This PR upgrades the Sandbox to work with Java 20. Compatibility with earlier releases is not guaranteed. For this, please use version 0.3.x.

This is to ensure the Sandbox stays compatible with the [Graal JS Sandbox](https://github.com/javadelight/delight-graaljs-sandbox), see https://github.com/javadelight/delight-graaljs-sandbox/pull/9