### PR TITLE
Make more compatible with JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
 			<groupId>org.webjars.npm</groupId>
 			<artifactId>js-beautify</artifactId>
 			<version>1.14.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.nashorn</groupId>
@@ -155,6 +161,7 @@
 						</Service-Component>
 						<Bundle-RequiredExecutionEnvironment>JavaSE-1.6
 						</Bundle-RequiredExecutionEnvironment>
+                        <Automatic-Module-Name>org.javadelight.nashornsandbox</Automatic-Module-Name>
 					</instructions>
 				</configuration>
 			</plugin>
@@ -171,11 +178,11 @@
 							<goal>run</goal>
 						</goals>
 						<configuration>
-							<tasks>
+							<target>
 								<delete file="${basedir}/META-INF/MANIFEST.MF" />
 								<copy file="target/classes/META-INF/MANIFEST.MF"
 									tofile="${basedir}/META-INF/MANIFEST.MF" />
-							</tasks>
+							</target>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
+++ b/src/main/java/delight/nashornsandbox/internal/JsSanitizer.java
@@ -47,7 +47,7 @@ public class JsSanitizer {
 	}
 
 	/** The resource name of beautify.min.js script. */
-	private final static String BEAUTIFY_JS = "/META-INF/resources/webjars/js-beautify/1.14.7/js/lib/beautifier.js";
+	private final static String BEAUTIFY_JS = "META-INF/resources/webjars/js-beautify/1.14.7/js/lib/beautifier.js";
 
 	/** The beautify function search list. */
 	private static final List<String> BEAUTIFY_FUNCTIONS = Arrays.asList("exports.beautifier.js;", "window.js_beautify;", "exports.js_beautify;",
@@ -299,7 +299,8 @@ public class JsSanitizer {
 		String script = beautifysScript.get();
 		if (script == null) {
 			try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
-					new BufferedInputStream(JsSanitizer.class.getResourceAsStream(BEAUTIFY_JS)), StandardCharsets.UTF_8))) {
+					new BufferedInputStream(JsSanitizer.class.getClassLoader().getResourceAsStream(BEAUTIFY_JS)),
+					StandardCharsets.UTF_8))) {
 				final StringBuilder sb = new StringBuilder();
 				String line;
 				while ((line = reader.readLine()) != null) {
@@ -317,7 +318,7 @@ public class JsSanitizer {
 
     @SuppressWarnings("unchecked")
 	private static Function<String, String> beautifierAsFunction(Object beautifyScript) {
-      
+
         if (NashornDetection.isStandaloneNashornScriptObjectMirror(beautifyScript)) {
 			return script -> {
 				org.openjdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (org.openjdk.nashorn.api.scripting.ScriptObjectMirror) beautifyScript;


### PR DESCRIPTION
There are a few problems relating to JPMS support:

- Transitive dependencies of the beautifier web jar are pulled in. In practice only the beautifier itself (actually just one file of that JAR, the compiled beautifier.js) is needed. (This is not actually a JPMS issue, but i thought i'd change it while i am already changing the build script)
![image](https://github.com/user-attachments/assets/e64475df-3523-4646-99fd-d425f852779f)
- If this library gets loaded as a JPMS module (that was manually upgraded, or automatically via a buildsystem) it will not have access to the resources of other modules, which includes the beautifier web jar. This can be fixed by directly accessing the classloader in `JsSanitizer` (since resources accessed through the class loader are not module specific):

```diff
- 					new BufferedInputStream(JsSanitizer.class.getResourceAsStream(BEAUTIFY_JS)), StandardCharsets.UTF_8))) {
+					new BufferedInputStream(JsSanitizer.class.getClassLoader().getResourceAsStream(BEAUTIFY_JS)), StandardCharsets.UTF_8))) {
```
- Lastly this package is not a JPMS module, but can also not be included as a JPMS module in gradle due to a shortcoming of gradles automatic module support (https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular). A non-invasive fix for this is to add a `Automatic-Module-Name` attribute to the `MANIFEST.MF` which will allow gradle to generate a `module-info.java` if the project requires this, while not adding any module-info for projects that dont already make use of it.
