### PR TITLE
Fixing issue #170

### DIFF
--- a/injectJs/src/index.js
+++ b/injectJs/src/index.js
@@ -63,7 +63,6 @@ const injectJs = function (code, insertCode) {
           node.body = newBody;
         }
         statementCount = 0;
-        return node;
       }
     },
     leave: function (node, parent) {

--- a/injectJs/src/index.test.js
+++ b/injectJs/src/index.test.js
@@ -451,4 +451,58 @@ exampleFunction();
     `
     testSanitizer(inputCode, expectedOutputCode);
   });
+
+  it('should not duplicate code if is function, for, ...', () => {
+    const inputCode = `
+function exampleFunction() {
+    print("init");
+            
+    var data = [];
+    data.push("a1");
+    data.push("a2");
+    data.push("a3");
+    data.push("a4");
+    data.push("a5");
+    data.push("a6");
+    data.push("a7");
+    data.push("a8");
+    data.push("a9");
+
+    print("pushed mandatory columns");
+    
+    for (var i = 0; i < data.length; i++) {
+        print(data[i]);
+    }
+    
+    print("finished");
+}
+
+exampleFunction();
+    `;
+    var expectedOutputCode = `
+function exampleFunction() {
+    __if();
+    print('init');
+    var data = [];
+    data.push('a1');
+    data.push('a2');
+    data.push('a3');
+    data.push('a4');
+    data.push('a5');
+    data.push('a6');
+    data.push('a7');
+    __if();
+    data.push('a8');
+    data.push('a9');
+    print('pushed mandatory columns');
+    for (var i = 0; i < data.length; i++) {
+        __if();
+        print(data[i]);
+    }
+    print('finished');
+}
+exampleFunction();
+    `
+    testSanitizer(inputCode, expectedOutputCode);
+  });
 });


### PR DESCRIPTION
Returning the node from the traversal function caused estraverse to stop going deeper at that point,
which led to duplicated or missing lines in the generated code.
Removing the return statement allows estraverse to continue processing the entire AST properly, preventing these issues.

I also adjusted the tests with the example from issue #170.
All the other things work just as before.

Hopefully, we can close #170 with this change.